### PR TITLE
Build for all archs for compatibility with universal targets

### DIFF
--- a/PivotalCoreKit.xcodeproj/project.pbxproj
+++ b/PivotalCoreKit.xcodeproj/project.pbxproj
@@ -1055,7 +1055,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PREBINDING = NO;
 				SDKROOT = macosx10.6;
 			};
@@ -1069,7 +1069,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PREBINDING = NO;
 				SDKROOT = macosx10.6;
 			};


### PR DESCRIPTION
Universal targets build for armv6 and armv7. 

If a dependent project is set to 

```
ONLY_ACTIVE_ARCH = YES
```

the parent project will fail to build.
