### PR TITLE
Dismiss XCode 4.4 high resolution artwork warning

### DIFF
--- a/PivotalCoreKit.xcodeproj/project.pbxproj
+++ b/PivotalCoreKit.xcodeproj/project.pbxproj
@@ -1001,7 +1001,7 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0420;
+				LastUpgradeCheck = 0450;
 			};
 			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "PivotalCoreKit" */;
 			compatibilityVersion = "Xcode 3.2";


### PR DESCRIPTION
This changeset should make this pesky build warning stop appearing in projects that include PivotalCoreKit.
