### PR TITLE
Add new stubbed UIViewController animation method

### DIFF
--- a/UIKit/SpecHelper/Stubs/UIViewController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIViewController+Spec.m
@@ -71,5 +71,10 @@ static char PRESENTED_CONTROLLER_KEY;
     completion(YES);
 }
 
+- (void)transitionFromViewController:(UIViewController *)fromViewController toViewController:(UIViewController *)toViewController duration:(NSTimeInterval)duration options:(UIViewAnimationOptions)options animations:(void (^)(void))animations completion:(void (^)(BOOL))completion {
+    animations();
+    completion(YES);
+}
+
 @end
 #pragma clang diagnostic pop


### PR DESCRIPTION
We're using transitionFromViewController:toViewController: on a client project. In our tests, we're stubbing it out the same way that PCK stubs out animateWithDuration. It's pretty trivial, but including it in here might save someone else writing a half-dozen lines of code and a new category.
