### PR TITLE
Update PCKHTTPConnection.h

### DIFF
--- a/Foundation/Core/Interfaces/PCKHTTPConnection.h
+++ b/Foundation/Core/Interfaces/PCKHTTPConnection.h
@@ -1,9 +1,8 @@
 #import <Foundation/Foundation.h>
-#import "NSURLConnectionDelegate.h"
 
 @class PCKHTTPInterface;
 
-@interface PCKHTTPConnection : NSURLConnection <NSURLConnectionDelegate>
+@interface PCKHTTPConnection : NSURLConnection
 
 - (id)initWithHTTPInterface:(PCKHTTPInterface *)interface forRequest:(NSURLRequest *)request andDelegate:(id<NSURLConnectionDelegate>)delegate;
 


### PR DESCRIPTION
PCKHTTPConnection does not actually implement NSURLConnectionDelegate methods, so it should not conform to the NSURLConnectionDelegate protocol, nor should it import the protocol.
