### PR TITLE
Backfilled UIViewController+Spec specs; Added UINavigationController dismissals

### DIFF
--- a/UIKit/Spec/Stubs/UIViewControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIViewControllerSpec+Spec.mm
@@ -1,0 +1,152 @@
+#import <UIKit/UIKit.h>
+#import <Cedar-iOS.h>
+#import <SpecHelper.h>
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(UIViewControllerSpec)
+
+describe(@"UIViewController (spec extensions)", ^{
+    __block UIViewController *controller, *childController;
+    __block UINavigationController *modalController;
+
+    beforeEach(^{
+        controller = [[UIViewController new] autorelease];
+        childController = [[UIViewController new] autorelease];
+        modalController = [[[UINavigationController alloc] initWithRootViewController:childController] autorelease];
+    });
+
+    describe(@"presenting modal view controllers", ^{
+        __block BOOL completeBlockWasCalled;
+        beforeEach(^{
+            completeBlockWasCalled = NO;
+            [controller presentViewController:modalController animated:YES completion:^{
+                completeBlockWasCalled = YES;
+            }];
+        });
+
+        it(@"should invoke the complete block", ^{
+            completeBlockWasCalled should be_truthy;
+        });
+
+        it(@"should set the presentedViewController as the modal controller", ^{
+            controller.presentedViewController should be_same_instance_as(modalController);
+        });
+
+        it(@"should set the presentingViewController on the modal controller", ^{
+            modalController.presentingViewController should be_same_instance_as(controller);
+        });
+
+        describe(@"dismissing the modal using a child view controller", ^{
+            beforeEach(^{
+                completeBlockWasCalled = NO;
+                [childController dismissViewControllerAnimated:YES completion:^{
+                    completeBlockWasCalled = YES;
+                }];
+            });
+
+            it(@"should invoke the complete block", ^{
+                completeBlockWasCalled should be_truthy;
+            });
+
+            it(@"should remove the presented view controller", ^{
+                controller.presentedViewController should be_nil;
+            });
+
+            it(@"should remove the presenting view controller", ^{
+                modalController.presentingViewController should be_nil;
+            });
+        });
+
+        describe(@"dismissing the modal using the parent view controller", ^{
+            beforeEach(^{
+                completeBlockWasCalled = NO;
+                [controller dismissViewControllerAnimated:YES completion:^{
+                    completeBlockWasCalled = YES;
+                }];
+            });
+
+            it(@"should invoke the complete block", ^{
+                completeBlockWasCalled should be_truthy;
+            });
+
+            it(@"should remove the presented view controller", ^{
+                controller.presentedViewController should be_nil;
+            });
+
+            it(@"should remove the presenting view controller", ^{
+                modalController.presentingViewController should be_nil;
+            });
+        });
+
+        describe(@"dismissing the modal using the modal view controller", ^{
+            beforeEach(^{
+                completeBlockWasCalled = NO;
+                [modalController dismissViewControllerAnimated:YES completion:^{
+                    completeBlockWasCalled = YES;
+                }];
+            });
+
+            it(@"should invoke the complete block", ^{
+                completeBlockWasCalled should be_truthy;
+            });
+
+            it(@"should remove the presented view controller", ^{
+                controller.presentedViewController should be_nil;
+            });
+
+            it(@"should remove the presenting view controller", ^{
+                modalController.presentingViewController should be_nil;
+            });
+        });
+
+        describe(@"presenting another modal controller", ^{
+            it(@"should raise an exception", ^{
+                ^{
+                    [controller presentViewController:[[UIViewController new] autorelease] animated:YES completion:nil];
+                } should raise_exception;
+            });
+        });
+    });
+
+    describe(@"presenting modal view controllers (deprecated APIs)", ^{
+        beforeEach(^{
+            [controller presentModalViewController:modalController animated:YES];
+        });
+
+        it(@"should set the presentedViewController as the modal controller", ^{
+            controller.presentedViewController should be_same_instance_as(modalController);
+        });
+
+        describe(@"dismissing the modal using a child view controller", ^{
+            beforeEach(^{
+                [childController dismissModalViewControllerAnimated:YES];
+            });
+
+            it(@"should remove the presented view controller", ^{
+                controller.presentedViewController should be_nil;
+            });
+
+            it(@"should remove the presenting view controller", ^{
+                modalController.presentingViewController should be_nil;
+            });
+        });
+
+        describe(@"dismissing the modal using the parent view controller", ^{
+            beforeEach(^{
+                [controller dismissModalViewControllerAnimated:YES];
+            });
+
+            it(@"should remove the presented view controller", ^{
+                controller.presentedViewController should be_nil;
+            });
+
+            it(@"should remove the presenting view controller", ^{
+                modalController.presentingViewController should be_nil;
+            });
+        });
+    });
+});
+
+SPEC_END

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		AE3847B8168BA3B500C99B55 /* UIImage+PivotalCore.m in Sources */ = {isa = PBXBuildFile; fileRef = AEBCCBD0168B96C80056EE83 /* UIImage+PivotalCore.m */; };
 		AE3847B9168BA3B500C99B55 /* UIView+PivotalCore.m in Sources */ = {isa = PBXBuildFile; fileRef = AEBCCBD2168B96C80056EE83 /* UIView+PivotalCore.m */; };
 		AE3847BD168BACEB00C99B55 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AEBCCC39168B99ED0056EE83 /* CoreGraphics.framework */; };
+		AE7B279617CFD67600904F64 /* UIViewControllerSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE7B279517CFD67600904F64 /* UIViewControllerSpec+Spec.mm */; };
 		AE86BD42179C7C910057DEAE /* UITabBarController+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE86BD40179C7C910057DEAE /* UITabBarController+Spec.h */; };
 		AE86BD43179C7C910057DEAE /* UITabBarController+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE86BD41179C7C910057DEAE /* UITabBarController+Spec.m */; };
 		AE86BD4E179C7DAD0057DEAE /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AE86BD4D179C7DAD0057DEAE /* Default-568h@2x.png */; };
@@ -253,6 +254,7 @@
 		AE3847A8168BA0B300C99B55 /* AWebViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AWebViewController.xib; sourceTree = "<group>"; };
 		AE3847AA168BA0B300C99B55 /* logo-small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "logo-small.png"; sourceTree = "<group>"; };
 		AE3847AB168BA0B300C99B55 /* pivotallabs-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "pivotallabs-logo.png"; sourceTree = "<group>"; };
+		AE7B279517CFD67600904F64 /* UIViewControllerSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIViewControllerSpec+Spec.mm"; sourceTree = "<group>"; };
 		AE86BD40179C7C910057DEAE /* UITabBarController+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBarController+Spec.h"; sourceTree = "<group>"; };
 		AE86BD41179C7C910057DEAE /* UITabBarController+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITabBarController+Spec.m"; sourceTree = "<group>"; };
 		AE86BD4D179C7DAD0057DEAE /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "../Default-568h@2x.png"; sourceTree = "<group>"; };
@@ -533,6 +535,7 @@
 			children = (
 				AEC40CBE174C24CF00474D2D /* UIAlertViewSpec+Spec.mm */,
 				AEC40CBF174C24CF00474D2D /* UIWebViewSpec+Spec.mm */,
+				AE7B279517CFD67600904F64 /* UIViewControllerSpec+Spec.mm */,
 			);
 			path = Stubs;
 			sourceTree = "<group>";
@@ -809,6 +812,7 @@
 				AEC40CC0174C24CF00474D2D /* UIAlertViewSpec+Spec.mm in Sources */,
 				AEC40CC1174C24CF00474D2D /* UIWebViewSpec+Spec.mm in Sources */,
 				AED4BE441780C8C800390AFD /* UITabBarControllerSpec+Spec.mm in Sources */,
+				AE7B279617CFD67600904F64 /* UIViewControllerSpec+Spec.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Added support for dismissing properly if a child controller is ask to dismiss inside of a modal UINavigationController.

We also refactored the code slightly to avoid using the pragmas to ignore deprecation warnings.
