### PR TITLE
Add support for -tap on UICollectionViewCell

### DIFF
--- a/PivotalCoreKit.xcworkspace/xcshareddata/PivotalCoreKit.xccheckout
+++ b/PivotalCoreKit.xcworkspace/xcshareddata/PivotalCoreKit.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>80166D14-80EF-49E5-AB29-5DDFFE3A1FA3</string>
+	<key>IDESourceControlProjectName</key>
+	<string>PivotalCoreKit</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>5A1D4E9A-20AE-4C43-876B-71C0DB035674</key>
+		<string>https://github.com/alexbasson/PivotalCoreKit.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>PivotalCoreKit.xcworkspace</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>5A1D4E9A-20AE-4C43-876B-71C0DB035674</key>
+		<string>..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>https://github.com/alexbasson/PivotalCoreKit.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>110</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>5A1D4E9A-20AE-4C43-876B-71C0DB035674</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>5A1D4E9A-20AE-4C43-876B-71C0DB035674</string>
+			<key>IDESourceControlWCCName</key>
+			<string>PivotalCoreKit</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/UIKit/Spec/Extensions/UICollectionViewCellSpec+Spec.mm
+++ b/UIKit/Spec/Extensions/UICollectionViewCellSpec+Spec.mm
@@ -1,0 +1,82 @@
+#import "SpecHelper.h"
+#import "UICollectionViewCell+Spec.h"
+
+@interface SpecCollectionViewController : UICollectionViewController
+@end
+
+@implementation SpecCollectionViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    [self.collectionView registerClass:[UICollectionViewCell class] forCellWithReuseIdentifier:@"Cell"];
+}
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return 2;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    return [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
+}
+
+@end
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(UICollectionViewCell_SpecSpec)
+
+describe(@"UICollectionViewCell+Spec", ^{
+    __block SpecCollectionViewController *controller;
+    __block UICollectionViewCell *cell;
+
+    beforeEach(^{
+        UICollectionViewFlowLayout *layout = [[[UICollectionViewFlowLayout alloc] init] autorelease];
+        controller = [[[SpecCollectionViewController alloc] initWithCollectionViewLayout:layout] autorelease];
+        controller.view should_not be_nil;
+        [controller.view layoutIfNeeded];
+
+        cell = controller.collectionView.visibleCells[0];
+    });
+
+    describe(@"-tap", ^{
+        subjectAction(^{ [cell tap]; });
+
+        context(@"for a single selection collection view", ^{
+            it(@"should result in the cell being selected", ^{
+                [controller.collectionView indexPathsForSelectedItems][0] should equal([controller.collectionView indexPathForCell:cell]);
+            });
+
+            it(@"should deselect the cell if another cell is tapped", ^{
+                [controller.collectionView.visibleCells[1] tap];
+
+                [controller.collectionView indexPathsForSelectedItems][0] should_not equal([controller.collectionView indexPathForCell:cell]);
+            });
+        });
+
+        context(@"for a multiple selection collection view", ^{
+            beforeEach(^{
+                [controller.collectionView setAllowsMultipleSelection:YES];
+            });
+
+            it(@"should results in the cell being selected", ^{
+                [controller.collectionView indexPathsForSelectedItems][0] should equal ([controller.collectionView indexPathForCell:cell]);
+            });
+
+            it(@"should deselect the cell if tapped again", ^{
+                [cell tap];
+
+                [controller.collectionView indexPathsForSelectedItems] should_not contain([controller.collectionView indexPathForCell:cell]);
+            });
+
+            it(@"should not deselect the cell if another cell is tapped", ^{
+                [controller.collectionView.visibleCells[1] tap];
+
+                [controller.collectionView indexPathsForSelectedItems] should contain([NSIndexPath indexPathForItem:0 inSection:0]);
+                [controller.collectionView indexPathsForSelectedItems] should contain([NSIndexPath indexPathForItem:1 inSection:0]);
+            });
+        });
+    });
+});
+
+SPEC_END

--- a/UIKit/SpecHelper/Extensions/UICollectionViewCell+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UICollectionViewCell+Spec.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface UICollectionViewCell (Spec)
+
+- (void)tap;
+
+@end

--- a/UIKit/SpecHelper/Extensions/UICollectionViewCell+Spec.m
+++ b/UIKit/SpecHelper/Extensions/UICollectionViewCell+Spec.m
@@ -1,0 +1,31 @@
+#import "UICollectionViewCell+Spec.h"
+
+@implementation UICollectionViewCell (Spec)
+
+- (void)tap {
+    UIView *currentView = self;
+    while (currentView.superview != nil && ![currentView isKindOfClass:[UICollectionView class]]) {
+        currentView = currentView.superview;
+    }
+
+    NSAssert(currentView, @"Cell must be a in a collection view in order to be tapped!");
+    UICollectionView *collectionView = (UICollectionView *)currentView;
+
+    NSIndexPath *indexPath = [collectionView indexPathForCell:self];
+
+    if (indexPath != nil) {
+        if (collectionView.allowsMultipleSelection && [collectionView.indexPathsForSelectedItems containsObject:indexPath]) {
+            [collectionView deselectItemAtIndexPath:indexPath animated:NO];
+            if ([collectionView.delegate respondsToSelector:@selector(collectionView:didDeselectItemAtIndexPath:)]) {
+                [collectionView.delegate collectionView:collectionView didDeselectItemAtIndexPath:indexPath];
+            }
+        } else {
+            [collectionView selectItemAtIndexPath:indexPath animated:NO scrollPosition:UICollectionViewScrollPositionNone];
+            if ([collectionView.delegate respondsToSelector:@selector(collectionView:didSelectItemAtIndexPath:)]) {
+                [collectionView.delegate collectionView:collectionView didSelectItemAtIndexPath:indexPath];
+            }
+        }
+    }
+}
+
+@end

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		B8C62E6F16BC04230009CDAD /* UIBarButtonItemSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = B8C62E6E16BC04230009CDAD /* UIBarButtonItemSpec+Spec.mm */; };
 		B8C62E7216BC04940009CDAD /* Target.m in Sources */ = {isa = PBXBuildFile; fileRef = B8C62E7116BC04940009CDAD /* Target.m */; };
 		B8C62E7316BC07F60009CDAD /* UIBarButtonItem+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = B8C62E6B16BC03420009CDAD /* UIBarButtonItem+Spec.h */; };
+		FA07586A18120D19001817BF /* UICollectionViewCell+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = FA07586918120D19001817BF /* UICollectionViewCell+Spec.m */; };
+		FA07586B18120E47001817BF /* UICollectionViewCellSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA07586618120BB1001817BF /* UICollectionViewCellSpec+Spec.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -314,6 +316,9 @@
 		B8C62E6E16BC04230009CDAD /* UIBarButtonItemSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIBarButtonItemSpec+Spec.mm"; sourceTree = "<group>"; };
 		B8C62E7016BC04940009CDAD /* Target.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Target.h; sourceTree = "<group>"; };
 		B8C62E7116BC04940009CDAD /* Target.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Target.m; sourceTree = "<group>"; };
+		FA07586618120BB1001817BF /* UICollectionViewCellSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UICollectionViewCellSpec+Spec.mm"; sourceTree = "<group>"; };
+		FA07586818120D19001817BF /* UICollectionViewCell+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UICollectionViewCell+Spec.h"; sourceTree = "<group>"; };
+		FA07586918120D19001817BF /* UICollectionViewCell+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UICollectionViewCell+Spec.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -510,6 +515,8 @@
 				AEBCCC7C168B9B5F0056EE83 /* UIView+Spec.m */,
 				AE53E2EA18075A810037C32E /* UIWindow+Spec.h */,
 				AE53E2EB18075A810037C32E /* UIWindow+Spec.m */,
+				FA07586818120D19001817BF /* UICollectionViewCell+Spec.h */,
+				FA07586918120D19001817BF /* UICollectionViewCell+Spec.m */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -527,6 +534,7 @@
 				AE1FBEA217D15A4100B0F03B /* UITableViewCellSpec+Spec.mm */,
 				AEBCCC95168B9C530056EE83 /* UIView+PivotalCoreSpec.mm */,
 				AE53E2F518075B080037C32E /* UIWindowSpec+Spec.mm */,
+				FA07586618120BB1001817BF /* UICollectionViewCellSpec+Spec.mm */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -808,6 +816,7 @@
 			files = (
 				AE3847B7168BA3B500C99B55 /* UIBarButtonItem+Button.m in Sources */,
 				AE3847B8168BA3B500C99B55 /* UIImage+PivotalCore.m in Sources */,
+				FA07586A18120D19001817BF /* UICollectionViewCell+Spec.m in Sources */,
 				AE3847B9168BA3B500C99B55 /* UIView+PivotalCore.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -820,6 +829,7 @@
 				AE1FBEA317D15A4100B0F03B /* UITableViewCellSpec+Spec.mm in Sources */,
 				AEBCCC9A168B9C530056EE83 /* UIImage+PivotalCoreSpec.mm in Sources */,
 				AE53E2F618075B080037C32E /* UIWindowSpec+Spec.mm in Sources */,
+				FA07586B18120E47001817BF /* UICollectionViewCellSpec+Spec.mm in Sources */,
 				AEBCCC9B168B9C530056EE83 /* UIImageSpec+Spec.mm in Sources */,
 				AEBCCC9C168B9C530056EE83 /* UIView+PivotalCoreSpec.mm in Sources */,
 				AEBCCC9E168B9C530056EE83 /* main.m in Sources */,


### PR DESCRIPTION
Analogous to -tap on UITableViewCell.

Note: Test for "-tap for a multiple selection collection view should not deselect the cell if another cell is tapped" asserts that `[controller.collectionView indexPathsForSelectedItems]` contains the relevant index paths rather than asserting equality of the returned array with `@[relevant index paths]`; this is because when running the specs via rake, `-indexPathsForSelectedItems` returns the array in reverse order for some reason, causing failure if the test asserts equality on the arrays.
