### PR TITLE
Adds a category on NSUserDefaults so that any user added keys are cleared out between spec runs.

### DIFF
--- a/Foundation/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation/Foundation.xcodeproj/project.pbxproj
@@ -40,6 +40,10 @@
 		AE6898DE16BC3AF700F3F6BC /* NSArray+PivotalCore.m in Sources */ = {isa = PBXBuildFile; fileRef = AE6898DB16BC3AF700F3F6BC /* NSArray+PivotalCore.m */; };
 		AE6898E716BC3B7A00F3F6BC /* NSArraySpec+PivotalCore.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE6898E616BC3B7A00F3F6BC /* NSArraySpec+PivotalCore.mm */; };
 		AE6898E816BC3D0500F3F6BC /* NSArraySpec+PivotalCore.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE6898E616BC3B7A00F3F6BC /* NSArraySpec+PivotalCore.mm */; };
+		AE8F8484182DA90C00A600E5 /* NSUserDefaults+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE8F8483182DA90C00A600E5 /* NSUserDefaults+Spec.m */; };
+		AE8F8485182DA90C00A600E5 /* NSUserDefaults+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE8F8483182DA90C00A600E5 /* NSUserDefaults+Spec.m */; };
+		AE8F8487182DAF6700A600E5 /* NSUserDefaultsSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE8F8486182DAF6700A600E5 /* NSUserDefaultsSpec.mm */; };
+		AE8F8488182DAF6700A600E5 /* NSUserDefaultsSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE8F8486182DAF6700A600E5 /* NSUserDefaultsSpec.mm */; };
 		AE9F8EF917C9B3670094079B /* PSHKObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE99C52A2D323A2A8E4F3EBF /* PSHKObserver.m */; };
 		AE9F8EFA17C9B3680094079B /* PSHKObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE99C52A2D323A2A8E4F3EBF /* PSHKObserver.m */; };
 		AEA96B7A168B50D900861DF1 /* NSData+PivotalCore.h in Headers */ = {isa = PBXBuildFile; fileRef = AEA96B5E168B50D900861DF1 /* NSData+PivotalCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -374,6 +378,9 @@
 		AE6898DB16BC3AF700F3F6BC /* NSArray+PivotalCore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+PivotalCore.m"; sourceTree = "<group>"; };
 		AE6898E616BC3B7A00F3F6BC /* NSArraySpec+PivotalCore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSArraySpec+PivotalCore.mm"; sourceTree = "<group>"; };
 		AE88B00711DE6D1200B65DD3 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
+		AE8F8482182DA90C00A600E5 /* NSUserDefaults+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSUserDefaults+Spec.h"; sourceTree = "<group>"; };
+		AE8F8483182DA90C00A600E5 /* NSUserDefaults+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSUserDefaults+Spec.m"; sourceTree = "<group>"; };
+		AE8F8486182DAF6700A600E5 /* NSUserDefaultsSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NSUserDefaultsSpec.mm; sourceTree = "<group>"; };
 		AEA96B49168B506500861DF1 /* Foundation+PivotalCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "Foundation+PivotalCore.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AEA96B5E168B50D900861DF1 /* NSData+PivotalCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+PivotalCore.h"; sourceTree = "<group>"; };
 		AEA96B5F168B50D900861DF1 /* NSData+PivotalCore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+PivotalCore.m"; sourceTree = "<group>"; };
@@ -659,6 +666,8 @@
 			isa = PBXGroup;
 			children = (
 				AE0CFF53176FE22200E6A958 /* NSURL+Spec.h */,
+				AE8F8482182DA90C00A600E5 /* NSUserDefaults+Spec.h */,
+				AE8F8483182DA90C00A600E5 /* NSUserDefaults+Spec.m */,
 				AE0CFF54176FE22200E6A958 /* NSURL+Spec.m */,
 				AEA96BB3168B544D00861DF1 /* NSURLConnection+Spec.h */,
 				AEA96BB4168B544D00861DF1 /* NSURLConnection+Spec.m */,
@@ -693,6 +702,7 @@
 		AEA96BE0168B56BF00861DF1 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				AE8F8486182DAF6700A600E5 /* NSUserDefaultsSpec.mm */,
 				AE6898E616BC3B7A00F3F6BC /* NSArraySpec+PivotalCore.mm */,
 				AEA96BE1168B56BF00861DF1 /* NSDataSpec+PivotalCore.mm */,
 				AE0CFF5F1770C80F00E6A958 /* NSDictionarySpec+QueryStringSpec.mm */,
@@ -1235,9 +1245,11 @@
 				AEA96C9A168B659500861DF1 /* main.m in Sources */,
 				AE6898E716BC3B7A00F3F6BC /* NSArraySpec+PivotalCore.mm in Sources */,
 				AEF6F87816EBF0CF0004F077 /* FakeOperationQueueSpec.mm in Sources */,
+				AE8F8487182DAF6700A600E5 /* NSUserDefaultsSpec.mm in Sources */,
 				E309449C16F3FD230034B3A9 /* ConnectionDelegate.m in Sources */,
 				AE9F8EF917C9B3670094079B /* PSHKObserver.m in Sources */,
 				E3F9C81116F50EED00347B30 /* PCKConnectionDelegateWrapperSpec.mm in Sources */,
+				AE8F8484182DA90C00A600E5 /* NSUserDefaults+Spec.m in Sources */,
 				E3F9C81416F50EFC00347B30 /* PCKConnectionBlockDelegateSpec.mm in Sources */,
 				AE0CFF601770C81900E6A958 /* NSDictionarySpec+QueryStringSpec.mm in Sources */,
 				AE0CFF7C1770DB0100E6A958 /* NSURLSpec+Spec.mm in Sources */,
@@ -1300,9 +1312,11 @@
 				AEA96CBE168B688700861DF1 /* FakeConnectionDelegate.m in Sources */,
 				AE6898E816BC3D0500F3F6BC /* NSArraySpec+PivotalCore.mm in Sources */,
 				AEF6F88016EBF7D80004F077 /* FakeOperationQueueSpec.mm in Sources */,
+				AE8F8488182DAF6700A600E5 /* NSUserDefaultsSpec.mm in Sources */,
 				E30944A416F3FD290034B3A9 /* ConnectionDelegate.m in Sources */,
 				AE9F8EFA17C9B3680094079B /* PSHKObserver.m in Sources */,
 				E3F9C81216F50EED00347B30 /* PCKConnectionDelegateWrapperSpec.mm in Sources */,
+				AE8F8485182DA90C00A600E5 /* NSUserDefaults+Spec.m in Sources */,
 				E3F9C81516F50EFC00347B30 /* PCKConnectionBlockDelegateSpec.mm in Sources */,
 				AE0CFF611770C81900E6A958 /* NSDictionarySpec+QueryStringSpec.mm in Sources */,
 				AE0CFF7D1770DB0100E6A958 /* NSURLSpec+Spec.mm in Sources */,

--- a/Foundation/Spec/Extensions/NSUserDefaultsSpec.mm
+++ b/Foundation/Spec/Extensions/NSUserDefaultsSpec.mm
@@ -1,0 +1,58 @@
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_IPHONE
+#import "SpecHelper.h"
+#else
+#import <Cedar/SpecHelper.h>
+#endif
+
+#import "NSUserDefaults+Spec.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(NSUserDefaultsSpec_Spec)
+
+describe(@"NSUserDefaults", ^{
+    NSUInteger countOfKeysBeforeTestRan = [[[[NSUserDefaults standardUserDefaults]
+                                          dictionaryRepresentation] allKeys] count];
+
+    // given that we cannot control which order these tests run in
+    // we need to run this test twice in order to ensure that
+    // the allKeys.count should equal(0) assertion is tested correctly
+    it(@"should allow you to store some user defaults", ^{
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        [[[userDefaults dictionaryRepresentation] allKeys] count] should equal(countOfKeysBeforeTestRan);
+
+        NSURL *arnyURL = [NSURL URLWithString:@"http://www.schwarzenegger.com/"];
+
+        [userDefaults setObject:@"DO IT NOW" forKey:@"GET TO TEH CHOPPAH"];
+        [userDefaults setURL:arnyURL forKey:@"Arnold"];
+        [userDefaults setFloat:12323.23 forKey:@"lbsBenched"];
+        [userDefaults setBool:YES forKey:@"i'll be back"];
+        [userDefaults setInteger:800 forKey:@"Terminator model number"];
+        [userDefaults setDouble:1000 forKey:@"Liquid Terminator model number"];
+
+        // assert that these values are set (because these methods are swizzled)
+        [userDefaults objectForKey:@"GET TO TEH CHOPPAH"] should equal(@"DO IT NOW");
+        [userDefaults URLForKey:@"Arnold"] should equal(arnyURL);
+        [userDefaults floatForKey:@"lbsBenched"] should be_close_to(12323.23);
+        [userDefaults boolForKey:@"i'll be back"] should be_truthy;
+        [userDefaults integerForKey:@"Terminator model number"] should equal(800);
+        [userDefaults doubleForKey:@"Liquid Terminator model number"] should equal(1000);
+    });
+
+    it(@"should not pollute your tests", ^{
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        [[[userDefaults dictionaryRepresentation] allKeys] count] should equal(countOfKeysBeforeTestRan);
+
+        [userDefaults setObject:@"DO IT NOW" forKey:@"GET TO TEH CHOPPAH"];
+        [userDefaults setURL:[NSURL URLWithString:@"http://www.schwarzenegger.com/"] forKey:@"Arnold"];
+        [userDefaults setFloat:12323.23 forKey:@"lbsBenched"];
+        [userDefaults setBool:YES forKey:@"i'll be back"];
+        [userDefaults setInteger:800 forKey:@"Terminator model number"];
+        [userDefaults setDouble:1000 forKey:@"Liquid Terminator model number"];
+    });
+});
+
+SPEC_END

--- a/Foundation/SpecHelper/Extensions/NSUserDefaults+Spec.h
+++ b/Foundation/SpecHelper/Extensions/NSUserDefaults+Spec.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface NSUserDefaults (Spec)
+
+@end

--- a/Foundation/SpecHelper/Extensions/NSUserDefaults+Spec.m
+++ b/Foundation/SpecHelper/Extensions/NSUserDefaults+Spec.m
@@ -1,0 +1,89 @@
+#import "NSUserDefaults+Spec.h"
+#import "NSObject+MethodRedirection.h"
+
+@interface NSUserDefaults (Spec_Private)
+-(void)setUnswizzledObject:(id)obj forKey:(NSString *)key;
+-(void)setUnswizzledURL:(NSURL *)url forKey:(NSString *)key;
+-(void)setUnswizzledFloat:(float)theFloat forKey:(NSString *)key;
+-(void)setUnswizzledBool:(BOOL)theBool forKey:(NSString *)key;
+-(void)setUnswizzledInteger:(NSInteger)theInt forKey:(NSString *)key;
+-(void)setUnswizzledDouble:(double)theDouble forKey:(NSString *)key;
+@end
+
+@implementation NSUserDefaults (Spec)
+
+static NSMutableArray *keys;
++(void)load {
+    keys = [[NSMutableArray alloc] init];
+
+
+    [NSUserDefaults redirectSelector:@selector(setObject:forKey:)
+                                  to:@selector(setSnoopedObject:forKey:)
+                       andRenameItTo:@selector(setUnswizzledObject:forKey:)];
+
+    [NSUserDefaults redirectSelector:@selector(setURL:forKey:)
+                                  to:@selector(setSnoopedURL:forKey:)
+                       andRenameItTo:@selector(setUnswizzledURL:forKey:)];
+
+    [NSUserDefaults redirectSelector:@selector(setFloat:forKey:)
+                                  to:@selector(setSnoopedFloat:forKey:)
+                       andRenameItTo:@selector(setUnswizzledFloat:forKey:)];
+
+    [NSUserDefaults redirectSelector:@selector(setBool:forKey:)
+                                  to:@selector(setSnoopedBool:forKey:)
+                       andRenameItTo:@selector(setUnswizzledBool:forKey:)];
+
+    [NSUserDefaults redirectSelector:@selector(setInteger:forKey:)
+                                  to:@selector(setSnoopedInteger:forKey:)
+                       andRenameItTo:@selector(setUnswizzledInteger:forKey:)];
+
+    [NSUserDefaults redirectSelector:@selector(setDouble:forKey:)
+                                  to:@selector(setSnoopedDouble:forKey:)
+                       andRenameItTo:@selector(setUnswizzledDouble:forKey:)];
+
+}
+
+#pragma mark - Cedar beforeEach helper
++(void)beforeEach {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSMutableArray *keysCopy = [keys copy];
+
+    [keysCopy enumerateObjectsUsingBlock:^(NSString *key, NSUInteger index, BOOL *stop) {
+        [defaults removeObjectForKey:key];
+    }];
+
+    keys = [[NSMutableArray alloc] init];
+}
+
+#pragma mark - swizzled methods
+-(void)setSnoopedObject:(id)obj forKey:(NSString *)key {
+    [keys addObject:key];
+    [self setUnswizzledObject:obj forKey:key];
+}
+
+-(void)setSnoopedURL:(NSURL *)url forKey:(NSString *)key {
+    [keys addObject:key];
+    [self setUnswizzledURL:url forKey:key];
+}
+
+-(void)setSnoopedFloat:(float)theFloat forKey:(NSString *)key {
+    [keys addObject:key];
+    [self setUnswizzledFloat:theFloat forKey:key];
+}
+
+-(void)setSnoopedBool:(BOOL)theBool forKey:(NSString *)key {
+    [keys addObject:key];
+    [self setUnswizzledBool:theBool forKey:key];
+}
+
+-(void)setSnoopedInteger:(NSInteger)theInt forKey:(NSString *)key {
+    [keys addObject:key];
+    [self setUnswizzledInteger:theInt forKey:key];
+}
+
+-(void)setSnoopedDouble:(double)theDouble forKey:(NSString *)key {
+    [keys addObject:key];
+    [self setUnswizzledDouble:theDouble forKey:key];
+}
+
+@end

--- a/PivotalCoreKit.xcworkspace/xcshareddata/PivotalCoreKit.xccheckout
+++ b/PivotalCoreKit.xcworkspace/xcshareddata/PivotalCoreKit.xccheckout
@@ -5,7 +5,7 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>18FCFEC7-56CC-42F3-85A4-BE724799D2C8</string>
+	<string>837A043E-7D26-4747-BC59-6B2124DC35A0</string>
 	<key>IDESourceControlProjectName</key>
 	<string>PivotalCoreKit</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
@@ -14,8 +14,8 @@
 		<string>https://github.com/akitchen/FakeHTTP.git</string>
 		<key>95415894-77E5-460B-AD63-C37A366D6DC4</key>
 		<string>git://github.com/pivotal/cedar.git</string>
-		<key>BB5BFF46-5B92-468A-B5C6-C137CF0A484C</key>
-		<string>https://github.com/pivotal/PivotalCoreKit.git</string>
+		<key>F5F969D1-9D5E-4D5B-BD84-FE61475356CA</key>
+		<string>https://github.com/mjstallard/PivotalCoreKit</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>PivotalCoreKit.xcworkspace</string>
@@ -25,15 +25,15 @@
 		<string>../Externals/FakeHTTP</string>
 		<key>95415894-77E5-460B-AD63-C37A366D6DC4</key>
 		<string>../Externals/Cedar</string>
-		<key>BB5BFF46-5B92-468A-B5C6-C137CF0A484C</key>
+		<key>F5F969D1-9D5E-4D5B-BD84-FE61475356CA</key>
 		<string>..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/pivotal/PivotalCoreKit.git</string>
+	<string>https://github.com/mjstallard/PivotalCoreKit</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>BB5BFF46-5B92-468A-B5C6-C137CF0A484C</string>
+	<string>F5F969D1-9D5E-4D5B-BD84-FE61475356CA</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
@@ -56,7 +56,7 @@
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>BB5BFF46-5B92-468A-B5C6-C137CF0A484C</string>
+			<string>F5F969D1-9D5E-4D5B-BD84-FE61475356CA</string>
 			<key>IDESourceControlWCCName</key>
 			<string>PivotalCoreKit</string>
 		</dict>


### PR DESCRIPTION
We've implemented this so that rather than blowing away NSUserDefaults entirely between specs, we just remove anything that was set in the test block. 

This was requested by @sweetleon who claimed he had already implemented it for several projects before. This should save someone approximately 20 minutes in the future (hopefully).
