### PR TITLE
Renames basePath to baseURLPath in Foundation.

### DIFF
--- a/Foundation/Core/Interfaces/PCKHTTPInterface.h
+++ b/Foundation/Core/Interfaces/PCKHTTPInterface.h
@@ -24,5 +24,5 @@ typedef void (^RequestSetupBlock)(NSMutableURLRequest *);
 // required
 - (NSString *)host;
 // optional
-- (NSString *)basePath;
+- (NSString *)baseURLPath;
 @end

--- a/Foundation/Core/Interfaces/PCKHTTPInterface.m
+++ b/Foundation/Core/Interfaces/PCKHTTPInterface.m
@@ -73,8 +73,8 @@
 
 - (NSURL *)newBaseURLAndPathWithProtocol:(NSString *)protocol {
     NSMutableString *baseURLString = [[NSMutableString alloc] initWithFormat:@"%@%@", protocol, [self host]];
-    if ([self respondsToSelector:@selector(basePath)]) {
-        [baseURLString appendString:[self basePath]];
+    if ([self respondsToSelector:@selector(baseURLPath)]) {
+        [baseURLString appendString:[self baseURLPath]];
     }
     NSURL *url = [[NSURL alloc] initWithString:baseURLString];
     [baseURLString release];

--- a/Foundation/Spec/Interfaces/PCKHTTPInterfaceSpec.mm
+++ b/Foundation/Spec/Interfaces/PCKHTTPInterfaceSpec.mm
@@ -12,7 +12,7 @@
 #import "NSURLConnectionDelegate.h"
 
 #define HOST "example.com"
-#define BASE_PATH "/v1/wibble/"
+#define BASE_URL_PATH "/v1/wibble/"
 #define PATH "foo/bar"
 
 @interface TestInterface : PCKHTTPInterface
@@ -24,8 +24,8 @@
     return @HOST;
 }
 
-- (NSString *)basePath {
-    return @BASE_PATH;
+- (NSString *)baseURLPath {
+    return @BASE_URL_PATH;
 }
 
 - (NSURLConnection *)makeConnectionWithDelegate:(id<NSURLConnectionDelegate>)delegate {
@@ -79,7 +79,7 @@ describe(@"PCKHTTPInterface", ^{
 
         it(@"should generate the target URI from the subclass-specific host and base path, along with the specified path", ^{
             expect(request.URL.host).to(equal(@HOST));
-            expect(request.URL.path).to(equal(@BASE_PATH PATH));
+            expect(request.URL.path).to(equal(@BASE_URL_PATH PATH));
         });
 
         it(@"should use the GET method", ^{
@@ -100,7 +100,7 @@ describe(@"PCKHTTPInterface", ^{
                 [interface makeConnectionWithDelegate:delegate];
 
                 interface should_not have_received("host");
-                interface should_not have_received("basePath");
+                interface should_not have_received("baseURLPath");
             });
         });
 
@@ -242,7 +242,7 @@ describe(@"PCKHTTPInterface", ^{
 
             it(@"should generate the target URI from the subclass-specific host and base path, along with the specified path", ^{
                 expect(request.URL.host).to(equal(@HOST));
-                expect(request.URL.path).to(equal(@BASE_PATH PATH));
+                expect(request.URL.path).to(equal(@BASE_URL_PATH PATH));
             });
 
             it(@"should use the GET method", ^{
@@ -261,7 +261,7 @@ describe(@"PCKHTTPInterface", ^{
 
             it(@"should generate the target URI from the subclass-specific host and base path, along with the specified path", ^{
                 expect(request.URL.host).to(equal(@HOST));
-                expect(request.URL.path).to(equal(@BASE_PATH PATH));
+                expect(request.URL.path).to(equal(@BASE_URL_PATH PATH));
             });
 
             it(@"should use the GET method", ^{


### PR DESCRIPTION
- Declaring any method named `basePath` in iOS7 will raise the following
  warning when validating for App Store release:
  
  > The app references non-public selectors in _app_name_: basePath
