### PR TITLE
Make UIGestureRecognizer+Spec work properly for gesture recognizers crea...

### DIFF
--- a/UIKit/Spec/Extensions/UIGestureRecognizerSpec+Spec.mm
+++ b/UIKit/Spec/Extensions/UIGestureRecognizerSpec+Spec.mm
@@ -2,6 +2,13 @@
 #import "UIGestureRecognizer+Spec.h"
 #import "Target.h"
 
+@interface SpecGestureRecognizerViewController : UIViewController
+@property (nonatomic, strong) IBOutlet UITapGestureRecognizer *recognizer;
+@property (nonatomic, strong) IBOutlet Target *target;
+@end
+@implementation SpecGestureRecognizerViewController
+@end
+
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
 
@@ -17,91 +24,116 @@ describe(@"UIGestureRecognizerSpec", ^{
         view = [[[UIView alloc] init] autorelease];
         target = [[[Target alloc] init] autorelease];
         spy_on(target);
-
-        recognizer = [[[UITapGestureRecognizer alloc] initWithTarget:target action:@selector(hello)] autorelease];
-        [view addGestureRecognizer:recognizer];
     });
 
-    describe(@"when initialized with a target", ^{
-        it(@"calls the target action when recognized", ^{
-            target should_not have_received(@selector(hello));
-            [recognizer recognize];
-            target should have_received(@selector(hello));
-        });
-
-        describe(@"when the view containing the gesture recognizer is hidden", ^{
-            beforeEach(^{
-                view.hidden = YES;
-            });
-
-            it(@"raises an exception", ^{
-                ^{
-                    [recognizer recognize];
-                } should raise_exception.with_reason(@"Can't recognize when in a hidden view");
-            });
-        });
-
-        describe(@"when the gesture recognizer is disabled", ^{
-            beforeEach(^{
-                recognizer.enabled = NO;
-            });
-
-            it(@"raises an exception", ^{
-                ^{
-                    [recognizer recognize];
-                } should raise_exception.with_reason(@"Can't recognize when recognizer is disabled");
-            });
-        });
-    });
-
-    describe(@"when additional targets are set", ^{
-        __block Target *newTarget;
-        beforeEach(^{
-            newTarget = [[[Target alloc] init] autorelease];
-            spy_on(newTarget);
-            [recognizer addTarget:newTarget action:@selector(goodbye)];
-        });
-
-        it(@"calls the additional target action when recognized", ^{
-            newTarget should_not have_received(@selector(goodbye));
-            [recognizer recognize];
-            newTarget should have_received(@selector(goodbye));
-        });
-    });
-
-    describe(@"when a target that takes the recognizer as an argument is set", ^{
-        __block Target *newTarget;
-        beforeEach(^{
-            newTarget = [[[Target alloc] init] autorelease];
-            spy_on(newTarget);
-            [recognizer addTarget:newTarget action:@selector(ciao:)];
-        });
-
-        it(@"calls the additional target action when recognized", ^{
-            newTarget should_not have_received(@selector(ciao:));
-            [recognizer recognize];
-            newTarget should have_received(@selector(ciao:)).with(recognizer);
-        });
-    });
-
-    describe(@"when initialized without a target or action", ^{
-        it(@"should not raise", ^{
-            UITapGestureRecognizer *recognizer = [[[UITapGestureRecognizer alloc] initWithTarget:nil action:nil] autorelease];
-            ^{
+    sharedExamplesFor(@"triggering a gesture recognizer", ^(NSDictionary *sharedContext) {
+        describe(@"when initialized with a target", ^{
+            it(@"calls the target action when recognized", ^{
+                target should_not have_received(@selector(hello));
                 [recognizer recognize];
-            } should_not raise_exception;
+                target should have_received(@selector(hello));
+            });
+
+            describe(@"when the view containing the gesture recognizer is hidden", ^{
+                beforeEach(^{
+                    view.hidden = YES;
+                });
+
+                it(@"raises an exception", ^{
+                    ^{
+                        [recognizer recognize];
+                    } should raise_exception.with_reason(@"Can't recognize when in a hidden view");
+                });
+            });
+
+            describe(@"when the gesture recognizer is disabled", ^{
+                beforeEach(^{
+                    recognizer.enabled = NO;
+                });
+
+                it(@"raises an exception", ^{
+                    ^{
+                        [recognizer recognize];
+                    } should raise_exception.with_reason(@"Can't recognize when recognizer is disabled");
+                });
+            });
+        });
+
+        describe(@"when additional targets are set", ^{
+            __block Target *newTarget;
+            beforeEach(^{
+                newTarget = [[[Target alloc] init] autorelease];
+                spy_on(newTarget);
+                [recognizer addTarget:newTarget action:@selector(goodbye)];
+            });
+
+            it(@"calls the additional target action when recognized", ^{
+                newTarget should_not have_received(@selector(goodbye));
+                [recognizer recognize];
+                newTarget should have_received(@selector(goodbye));
+            });
+        });
+
+        describe(@"when a target that takes the recognizer as an argument is set", ^{
+            __block Target *newTarget;
+            beforeEach(^{
+                newTarget = [[[Target alloc] init] autorelease];
+                spy_on(newTarget);
+                [recognizer addTarget:newTarget action:@selector(ciao:)];
+            });
+
+            it(@"calls the additional target action when recognized", ^{
+                newTarget should_not have_received(@selector(ciao:));
+                [recognizer recognize];
+                newTarget should have_received(@selector(ciao:)).with(recognizer);
+            });
+        });
+
+        describe(@"removing targets", ^{
+            beforeEach(^{
+                [recognizer removeTarget:target action:@selector(hello)];
+            });
+
+            it(@"should not call the action on the removed target", ^{
+                [recognizer recognize];
+                target should_not have_received(@selector(hello));
+            });
+        });
+
+    });
+
+    context(@"for a gesture recognizer created in code", ^{
+        beforeEach(^{
+            recognizer = [[[UITapGestureRecognizer alloc] initWithTarget:target action:@selector(hello)] autorelease];
+            [view addGestureRecognizer:recognizer];
+        });
+
+        itShouldBehaveLike(@"triggering a gesture recognizer");
+
+        describe(@"when initialized without a target or action", ^{
+            it(@"should not raise", ^{
+                UITapGestureRecognizer *recognizer = [[[UITapGestureRecognizer alloc] initWithTarget:nil action:nil] autorelease];
+                ^{
+                    [recognizer recognize];
+                } should_not raise_exception;
+            });
         });
     });
 
-    describe(@"removing targets", ^{
+    context(@"for a gesture recognizer created in a storyboard", ^{
+        __block SpecGestureRecognizerViewController *controller;
+
         beforeEach(^{
-            [recognizer removeTarget:target action:@selector(hello)];
+            controller = [[UIStoryboard storyboardWithName:@"UIGestureRecognizer" bundle:nil] instantiateInitialViewController];
+            controller.view should_not be_nil;
+
+            view = controller.view;
+            target = controller.target;
+            spy_on(target);
+            recognizer = controller.recognizer;
         });
 
-        it(@"should not call the action on the removed target", ^{
-            [recognizer recognize];
-            target should_not have_received(@selector(hello));
-        });
+        itShouldBehaveLike(@"triggering a gesture recognizer");
     });
 
     describe(@"cleaning up the installed whitelist", ^{

--- a/UIKit/Spec/Fixtures/Target.h
+++ b/UIKit/Spec/Fixtures/Target.h
@@ -4,7 +4,7 @@
 @interface Target : NSObject
 
 
-- (void)hello;
+- (IBAction)hello;
 - (void)goodbye;
 - (void)ciao:(id)bella;
 @end

--- a/UIKit/Spec/Fixtures/UIGestureRecognizer.storyboard
+++ b/UIKit/Spec/Fixtures/UIGestureRecognizer.storyboard
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="4YR-a3-PbR">
+    <dependencies>
+        <deployment defaultVersion="1280" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+    </dependencies>
+    <scenes>
+        <!--Spec Gesture Recognizer View Controller-->
+        <scene sceneID="rs7-zT-9ix">
+            <objects>
+                <viewController id="4YR-a3-PbR" customClass="SpecGestureRecognizerViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="GmH-VO-tp6"/>
+                        <viewControllerLayoutGuide type="bottom" id="Kux-nz-sRI"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="9O6-Qv-aqU">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <gestureRecognizers/>
+                        <connections>
+                            <outletCollection property="gestureRecognizers" destination="Esl-ah-oDv" appends="YES" id="L0X-Sb-C0m"/>
+                        </connections>
+                    </view>
+                    <connections>
+                        <outlet property="recognizer" destination="Esl-ah-oDv" id="MRm-yj-FoQ"/>
+                        <outlet property="target" destination="dCq-7c-sod" id="GFv-hf-sV4"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yY8-cR-KSm" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <customObject id="dCq-7c-sod" customClass="Target"/>
+                <tapGestureRecognizer id="Esl-ah-oDv">
+                    <connections>
+                        <action selector="hello" destination="dCq-7c-sod" id="umN-w9-LKA"/>
+                    </connections>
+                </tapGestureRecognizer>
+            </objects>
+            <point key="canvasLocation" x="240" y="25"/>
+        </scene>
+    </scenes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
+</document>

--- a/UIKit/SpecHelper/Extensions/UIGestureRecognizer+Spec.m
+++ b/UIKit/SpecHelper/Extensions/UIGestureRecognizer+Spec.m
@@ -50,7 +50,6 @@
 
 -(instancetype)initWithSwizzledTarget:(id)target action:(SEL)action {
     if (self = [self initWithoutSwizzledTarget:target action:action]) {
-        [self setTargetsAndActions:[[[NSMutableArray alloc] init] autorelease]];
         if(target && action) {
             [self addSnoopedTarget:target action:action];
         }
@@ -122,7 +121,12 @@ static NSMutableArray *whitelistedClasses;
 static char const * const targetAndActionsKey = "targetAndActionKey";
 
 -(NSMutableArray *) targetsAndActions {
-    return objc_getAssociatedObject(self, &targetAndActionsKey);
+    NSMutableArray *targetsAndActions = objc_getAssociatedObject(self, &targetAndActionsKey);
+    if (!targetsAndActions) {
+        targetsAndActions = [[[NSMutableArray alloc] init] autorelease];
+        [self setTargetsAndActions:targetsAndActions];
+    }
+    return targetsAndActions;
 }
 
 -(void) setTargetsAndActions:(NSMutableArray *)targetsAndActions {

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		22601B5916BA209F00A807CB /* UISliderSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 22601B5816BA209F00A807CB /* UISliderSpec+Spec.mm */; };
 		22601B5B16BA263A00A807CB /* UIKit+PivotalSpecHelper.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 22601B5A16BA263A00A807CB /* UIKit+PivotalSpecHelper.h */; };
 		22601B5C16BA274B00A807CB /* UISlider+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 22601B4D16BA202A00A807CB /* UISlider+Spec.h */; };
+		346281C618D7AC1300E9C952 /* UIGestureRecognizer.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 346281C518D7AC1300E9C952 /* UIGestureRecognizer.storyboard */; };
 		AE118AA418D6B57000C90D6B /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE118AA318D6B57000C90D6B /* SenTestingKit.framework */; };
 		AE118AA718D6B57000C90D6B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AEBCCBE7168B97DD0056EE83 /* Foundation.framework */; };
 		AE118AC218D6B63900C90D6B /* BundleSpecLoader.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE118AC118D6B63900C90D6B /* BundleSpecLoader.mm */; };
@@ -304,6 +305,7 @@
 		22601B4E16BA202A00A807CB /* UISlider+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UISlider+Spec.m"; sourceTree = "<group>"; };
 		22601B5816BA209F00A807CB /* UISliderSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UISliderSpec+Spec.mm"; sourceTree = "<group>"; };
 		22601B5A16BA263A00A807CB /* UIKit+PivotalSpecHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIKit+PivotalSpecHelper.h"; sourceTree = "<group>"; };
+		346281C518D7AC1300E9C952 /* UIGestureRecognizer.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = UIGestureRecognizer.storyboard; sourceTree = "<group>"; };
 		AE118AA218D6B57000C90D6B /* UIKit-StaticLibSpecBundle.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UIKit-StaticLibSpecBundle.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE118AA318D6B57000C90D6B /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		AE118AC118D6B63900C90D6B /* BundleSpecLoader.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BundleSpecLoader.mm; sourceTree = "<group>"; };
@@ -467,6 +469,7 @@
 				B8C62E7016BC04940009CDAD /* Target.h */,
 				B8C62E7116BC04940009CDAD /* Target.m */,
 				AEB315AB18BF830C00018EDD /* UITableViewCell.storyboard */,
+				346281C518D7AC1300E9C952 /* UIGestureRecognizer.storyboard */,
 				AE3847A9168BA0B300C99B55 /* Images */,
 			);
 			path = Fixtures;
@@ -901,6 +904,7 @@
 				AE3847AF168BA11D00C99B55 /* logo-small.png in Resources */,
 				AE3847B0168BA11D00C99B55 /* pivotallabs-logo.png in Resources */,
 				AE86BD4E179C7DAD0057DEAE /* Default-568h@2x.png in Resources */,
+				346281C618D7AC1300E9C952 /* UIGestureRecognizer.storyboard in Resources */,
 				AEB315B518BF841400018EDD /* UITableViewCell.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
...ted by storyboards
- Generate the `targetsAndActions` associated object on-demand, so it works even if `-initWithTarget:action:` is not invoked, because `-initWithCoder:` is used instead.
