### PR TITLE
Add 'Development' subspec to podspec

### DIFF
--- a/PivotalCoreKit.podspec
+++ b/PivotalCoreKit.podspec
@@ -15,6 +15,19 @@ Pod::Spec.new do |s|
     core.dependency 'PivotalCoreKit/Foundation/Core'
   end
 
+  s.subspec 'Development' do |dev|
+    dev.dependency 'PivotalCoreKit/Core'
+    dev.dependency 'PivotalCoreKit/Foundation/SpecHelper/Extensions'
+    dev.dependency 'PivotalCoreKit/Foundation/SpecHelper/Fixtures'
+    dev.dependency 'PivotalCoreKit/Foundation/SpecHelper/Helpers'
+    dev.dependency 'PivotalCoreKit/Foundation/SpecHelper/Fakes'
+    dev.dependency 'PivotalCoreKit/UIKit/SpecHelper/Extensions'
+    dev.dependency 'PivotalCoreKit/UIKit/SpecHelper/Matchers'
+    dev.dependency 'PivotalCoreKit/UIKit/SpecHelper/Stubs'
+    dev.dependency 'PivotalCoreKit/CoreLocation/SpecHelper/Base'
+    dev.dependency 'PivotalCoreKit/CoreLocation/SpecHelper/Extensions'
+  end
+
   s.subspec 'UIKit' do |ui|
     ui.subspec 'Core' do |uicore|
       uicore.source_files = 'UIKit/Core/**/*.{h,m}'


### PR DESCRIPTION
This PR adds a subspec that will help new developers (and any developer who just wants the whole enchilada really) to integrate the "development" portions of PCK into their project. It allows us to say simply, to "add PCK to your specs target, set up your podfile as follows:"

```
platform :ios, '7.0'
xcodeproj 'PLCoreKitExample.xcodeproj'
target :Specs do
    pod 'PivotalCoreKit/Development', '~> 0.0.1'
end
```

It's probably worth noting also that the 'PivotalCoreKit/Core' dependency MUST currently be part of the 'Development' subspec. This is because two spec helper extensions [NSUUID+Spec](https://github.com/pivotal/PivotalCoreKit/blob/master/Foundation/SpecHelper/Extensions/NSUUID%2BSpec.m) and [UIGestureRecognizer+Spec](https://github.com/pivotal/PivotalCoreKit/blob/master/UIKit/SpecHelper/Extensions/UIGestureRecognizer%2BSpec.m) currently rely on the 'redirectSelector:to:andRenameIt:' extension to NSObject in Foundation/Core. Also, interestingly, there is a comment in UIGestureRecognizer just above to local swizzle methods that say that this class should use the Foundation/Core swizzle methods - well, it does! (as an NSObject when Foundation/Core is linked)

I was not aware of these interdependencies before today!
