### PR TITLE
Run CI on iOS 6.0, 6.1, 7.0, and 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,14 @@ language: objective-c
 before_install:
   - git submodule update --init
 
+rvm:
+  - "system; export CEDAR_SDK_VERSION=7.1 #"
+
+env:
+  matrix:
+    - CEDAR_SDK_RUNTIME_VERSION="6.0"
+    - CEDAR_SDK_RUNTIME_VERSION="6.1"
+    - CEDAR_SDK_RUNTIME_VERSION="7.0"
+    - CEDAR_SDK_RUNTIME_VERSION="7.1"
+
 script: rake


### PR DESCRIPTION
[travis CI should run against iOSes 6, 6.1, 7, 7.1](https://www.pivotaltracker.com/story/show/67130024)

Run PCK specs using the following SDKs: 6.0, 6.1, 7.0, 7.1, all built with 7.1.
