### PR TITLE
Weakly retain popover controller in spec helper.

### DIFF
--- a/UIKit/SpecHelper/Stubs/UIPopoverController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIPopoverController+Spec.m
@@ -2,7 +2,7 @@
 
 @implementation UIPopoverController (Spec)
 
-static UIPopoverController *currentPopoverController__;
+__weak static UIPopoverController *currentPopoverController__;
 static UIPopoverArrowDirection arrowDirectionMask__;
 
 + (instancetype)currentPopoverController {


### PR DESCRIPTION
[UIPopoverController spec helper should not retain the popover](https://www.pivotaltracker.com/story/show/67252588)
