### PR TITLE
Add missing stubbed animation method.

### DIFF
--- a/UIKit/Spec/Stubs/UIViewSpec+StubbedAnimations.mm
+++ b/UIKit/Spec/Stubs/UIViewSpec+StubbedAnimations.mm
@@ -9,31 +9,90 @@ SPEC_BEGIN(UIView_StubbedAnimations)
 describe(@"UIView+StubbedAnimation", ^{
     __block BOOL animationBlockCalled;
     __block BOOL completionBlockCalled;
+
     beforeEach(^{
         animationBlockCalled = NO;
         completionBlockCalled = NO;
     });
 
+    describe(@"+animateWithDuration:animations:", ^{
+        beforeEach(^{
+            [UIView animateWithDuration:0.666 animations:^{
+                animationBlockCalled = YES;
+            }];
+        });
+
+        it(@"should call the animation block", ^{
+            animationBlockCalled should be_truthy;
+        });
+
+        it(@"should remember the duration", ^{
+            [UIView lastAnimationDuration] should be_close_to(.666);
+        });
+    });
+
     describe(@"+animateWithDuration:animations:completion:", ^{
-        subjectAction(^{
+        beforeEach(^{
             [UIView animateWithDuration:0.666 animations:^{
                 animationBlockCalled = YES;
             } completion:^(BOOL finished) {
                 completionBlockCalled = YES;
             }];
         });
-        
+
         it(@"should call the animation block", ^{
             animationBlockCalled should be_truthy;
         });
-        
+
         it(@"should call the completion block", ^{
             completionBlockCalled should be_truthy;
+        });
+
+        it(@"should remember the duration", ^{
+            [UIView lastAnimationDuration] should be_close_to(.666);
+        });
+    });
+
+    describe(@"+animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:", ^{
+        beforeEach(^{
+            [UIView animateWithDuration:0.666 delay:10 usingSpringWithDamping:176 initialSpringVelocity:117 options:UIViewAnimationOptionTransitionCrossDissolve animations:^{
+                animationBlockCalled = YES;
+            } completion:^(BOOL finished) {
+                completionBlockCalled = YES;
+            }];
+        });
+
+        it(@"should call the animation block", ^{
+            animationBlockCalled should be_truthy;
+        });
+
+        it(@"should call the completion block", ^{
+            completionBlockCalled should be_truthy;
+        });
+
+        it(@"should remember the damping ratio", ^{
+            [UIView lastAnimationSpringWithDamping] should be_close_to(176);
+        });
+
+        it(@"should remember the initial spring velocity", ^{
+            [UIView lastAnimationInitialSpringVelocity] should be_close_to(117);
+        });
+
+        it(@"should remember the duration", ^{
+            [UIView lastAnimationDuration] should be_close_to(.666);
+        });
+
+        it(@"should remember the delay", ^{
+            [UIView lastAnimationDelay] should be_close_to(10);
+        });
+
+        it(@"should remember the options", ^{
+            [UIView lastAnimationOptions] should equal(UIViewAnimationOptionTransitionCrossDissolve);
         });
     });
 
     describe(@"+animateWithDuration:delay:options:animations:completion:", ^{
-        subjectAction(^{
+        beforeEach(^{
             [UIView animateWithDuration:0.666 delay:10
                                 options:UIViewAnimationOptionTransitionFlipFromBottom
                              animations:^{

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.h
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.h
@@ -5,5 +5,7 @@
 + (NSTimeInterval)lastAnimationDuration;
 + (NSTimeInterval)lastAnimationDelay;
 + (UIViewAnimationOptions)lastAnimationOptions;
++ (CGFloat)lastAnimationSpringWithDamping;
++ (CGFloat)lastAnimationInitialSpringVelocity;
 
 @end

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.m
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.m
@@ -3,6 +3,8 @@
 static NSTimeInterval lastAnimationDuration__ = 0;
 static NSTimeInterval lastAnimationDelay__ = 0;
 static UIViewAnimationOptions lastAnimationOptions__ = 0;
+static CGFloat lastAnimationSpringWithDamping__ = 0;
+static CGFloat lastAnimationInitialSpringVelocity__ = 0;
 
 @implementation UIView (StubbedAnimation)
 
@@ -16,6 +18,14 @@ static UIViewAnimationOptions lastAnimationOptions__ = 0;
 
 + (UIViewAnimationOptions)lastAnimationOptions {
     return lastAnimationOptions__;
+}
+
++ (CGFloat)lastAnimationSpringWithDamping {
+    return lastAnimationSpringWithDamping__;
+}
+
++ (CGFloat)lastAnimationInitialSpringVelocity {
+    return lastAnimationInitialSpringVelocity__;
 }
 
 #pragma mark - Overrides
@@ -40,12 +50,20 @@ static UIViewAnimationOptions lastAnimationOptions__ = 0;
     [self animateWithDuration:duration animations:animations completion:completion];
 }
 
++ (void)animateWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay usingSpringWithDamping:(CGFloat)dampingRatio initialSpringVelocity:(CGFloat)velocity options:(UIViewAnimationOptions)options animations:(void (^)(void))animations completion:(void (^)(BOOL))completion {
+    lastAnimationSpringWithDamping__ = dampingRatio;
+    lastAnimationInitialSpringVelocity__ = velocity;
+    [self animateWithDuration:duration delay:delay options:options animations:animations completion:completion];
+}
+
 #pragma mark - CedarHooks
 
 + (void)beforeEach {
     lastAnimationDuration__ = 0;
     lastAnimationDelay__ = 0;
     lastAnimationOptions__ = 0;
+    lastAnimationSpringWithDamping__ = 0;
+    lastAnimationInitialSpringVelocity__ = 0;
 }
 
 @end


### PR DESCRIPTION
[Stub UIView animation methods](Stub UIView animation methods)

Also backfills tests for `animateWithDuration:animations:` and removes
whitespace.
