### PR TITLE
Update podspec for new arc requirement

### DIFF
--- a/PivotalCoreKit.podspec
+++ b/PivotalCoreKit.podspec
@@ -43,7 +43,16 @@ Pod::Spec.new do |s|
       end
 
       spec.subspec 'Stubs' do |stub|
+        stub.requires_arc = true
+        non_arc_files = 'UIKit/SpecHelper/Stubs/UIAlertView+Spec.m',
+                        'UIKit/SpecHelper/Stubs/UIActionSheet+Spec.m',
+                        'UIKit/SpecHelper/Stubs/UIWebView+Spec.m'
         stub.source_files = ['UIKit/SpecHelper/Stubs/*.{h,m}', 'UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h']
+        stub.exclude_files = non_arc_files
+        stub.subspec 'Stubs-no-arc' do |stub_noarc|
+          stub_noarc.requires_arc = false
+          stub_noarc.source_files = non_arc_files
+        end
       end
     end
   end
@@ -57,7 +66,7 @@ Pod::Spec.new do |s|
 
     f.subspec 'SpecHelper' do |spec_helper|
       spec_helper.subspec 'Extensions' do |ext|
-        ext.source_files = ['Foundation/Core/Extensions/NSObject+MethodRedirection.h', 'Foundation/SpecHelper/Helpers/PCKConnectionBlockDelegate.h', 'Foundation/SpecHelper/Helpers/PCKConnectionDelegateWrapper.h', 'Foundation/SpecHelper/Fakes/PSHKFakeHTTPURLResponse.h', 'Foundation/SpecHelper/Fakes/FakeOperationQueue.h', 'Foundation/SpecHelper/Extensions/*.{h,m}']
+        ext.source_files = ['Foundation/SpecHelper/Foundation+PivotalSpecHelper.h', 'Foundation/Core/Extensions/NSObject+MethodRedirection.h', 'Foundation/SpecHelper/Helpers/PCKConnectionBlockDelegate.h', 'Foundation/SpecHelper/Helpers/PCKConnectionDelegateWrapper.h', 'Foundation/SpecHelper/Fakes/PSHKFakeHTTPURLResponse.h', 'Foundation/SpecHelper/Fakes/FakeOperationQueue.h', 'Foundation/SpecHelper/Extensions/*.{h,m}']
       end
 
       spec_helper.subspec 'Fixtures' do |fix|


### PR DESCRIPTION
**Description:**
The change 10fbf74 on 4/1/2014 to `Add preprocessor check to UIPopoverController+Spec.m to ensure ARC is enabled` broke cocoapods compiling ability since the podspec was not updated to reflect the per file ARC settings - this PR fixes that problem. **Without this (or similar) change, pods users compilation will break badly if they try to use Core/SpecHelper/Stubs.** I might be nice  to add a story to the backlog to create an integration test to ensure that changes like this to source do not break things for pods users.

Also, I've added Foundation+PivotalSpecHelper.h to the exported sources for Foundation/SpecHelper so pods users can simply import that in the pch (or wherever) like we all love to do instead of importing the individual spec helpers in foundation.

**Changes:**
- Fix podspec to support arc requirement in specific file
  (UIPopOverController)
- Add Foundation+PivotalSpecHelper.h to exported source so it
  is easier to import the Foundation spec helpers in general.
