### PR TITLE
Add OSX support for PivotalCoreKit/Foundation sub-pod.

### DIFF
--- a/CoreLocation/CoreLocation.xcodeproj/project.pbxproj
+++ b/CoreLocation/CoreLocation.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 		AE3848CC168CD86000C99B55 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastTestingUpgradeCheck = 0510;
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = "Pivotal Labs";
 			};

--- a/PivotalCoreKit.podspec
+++ b/PivotalCoreKit.podspec
@@ -62,6 +62,8 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Foundation' do |f|
+    f.osx.deployment_target = '10.8'
+
     f.subspec 'Core' do |c|
       c.source_files = 'Foundation/Core/**/*.{h,m}'
       c.libraries    = 'xml2'

--- a/PivotalCoreKit.xcworkspace/xcshareddata/PivotalCoreKit.xccheckout
+++ b/PivotalCoreKit.xcworkspace/xcshareddata/PivotalCoreKit.xccheckout
@@ -5,58 +5,34 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>84C90FBA-07A0-4E01-96C2-CC87B943CCBF</string>
+	<string>B5B8D462-B5AA-492A-A9A9-CC000CE8C645</string>
 	<key>IDESourceControlProjectName</key>
 	<string>PivotalCoreKit</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>027D6D0C-B7CC-4DA3-809B-C4CAD8377340</key>
-		<string>https://github.com/akitchen/FakeHTTP.git</string>
-		<key>1BC383CE-2831-4C65-977B-E6E0A428E301</key>
-		<string>git://github.com/pivotal/cedar.git</string>
-		<key>8F8456F2-8607-47E4-85C9-45DA0D1432C9</key>
-		<string>https://github.com/pivotal/PivotalCoreKit.git</string>
+		<key>1B04C31A-8841-4BED-9969-6CA28C6A9F00</key>
+		<string>https://github.com/buddhistpirate/PivotalCoreKit.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>PivotalCoreKit.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>027D6D0C-B7CC-4DA3-809B-C4CAD8377340</key>
-		<string>../Externals/FakeHTTP</string>
-		<key>1BC383CE-2831-4C65-977B-E6E0A428E301</key>
-		<string>../Externals/Cedar</string>
-		<key>8F8456F2-8607-47E4-85C9-45DA0D1432C9</key>
+		<key>1B04C31A-8841-4BED-9969-6CA28C6A9F00</key>
 		<string>..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/pivotal/PivotalCoreKit.git</string>
+	<string>https://github.com/buddhistpirate/PivotalCoreKit.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>8F8456F2-8607-47E4-85C9-45DA0D1432C9</string>
+	<string>1B04C31A-8841-4BED-9969-6CA28C6A9F00</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>1BC383CE-2831-4C65-977B-E6E0A428E301</string>
-			<key>IDESourceControlWCCName</key>
-			<string>Cedar</string>
-		</dict>
-		<dict>
-			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
-			<string>public.vcs.git</string>
-			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>027D6D0C-B7CC-4DA3-809B-C4CAD8377340</string>
-			<key>IDESourceControlWCCName</key>
-			<string>FakeHTTP</string>
-		</dict>
-		<dict>
-			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
-			<string>public.vcs.git</string>
-			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>8F8456F2-8607-47E4-85C9-45DA0D1432C9</string>
+			<string>1B04C31A-8841-4BED-9969-6CA28C6A9F00</string>
 			<key>IDESourceControlWCCName</key>
 			<string>PivotalCoreKit</string>
 		</dict>


### PR DESCRIPTION
Hello!

We wanted to use some of the helpers in the Foundation sub-pod for an OSX project. However, the podspec specifies iOS as the platform. This makes sense for the iOS specific sub-pods, but AFIAK the Foundation sub-pod can be used for any objective-c project.

We added a OSX deployment target to the Foundation subspec, and the Foundation sub-pod now seems to work with OSX.

Thanks!
Geoff & Tim
