### PR TITLE
Re-enable Foundation for iOS

### DIFF
--- a/PivotalCoreKit.podspec
+++ b/PivotalCoreKit.podspec
@@ -63,6 +63,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Foundation' do |f|
     f.osx.deployment_target = '10.8'
+    f.ios.deployment_target = '6.0'
 
     f.subspec 'Core' do |c|
       c.source_files = 'Foundation/Core/**/*.{h,m}'


### PR DESCRIPTION
Fixed the ability to use PivotalCoreKit for iOS.

Perhaps there is a way to extract the version numbers, however PR #88 attempted this and ran into linting problems.  
