### PR TITLE
Fixed broken header reference for iOS 8.0 devices

### DIFF
--- a/UIKit/SpecHelper/Stubs/UIActivityViewController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIActivityViewController+Spec.m
@@ -1,5 +1,5 @@
 #import "UIActivityViewController+Spec.h"
-#import <objc/objc-runtime.h>
+#import <objc/runtime.h>
 
 static char kActivityItemsKey;
 static char kApplicationActivitesKey;


### PR DESCRIPTION
Oddly objc-runtime.h only exists in the iOS 8.0 simulator SDK, but not
the device SDK (verified on Xcode 6.0.1).
