### PR TITLE
Fix pod spec dependency when using just the UIKit SpecHelper Extensions sub-spec

### DIFF
--- a/PivotalCoreKit.podspec
+++ b/PivotalCoreKit.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
     ui.subspec 'SpecHelper' do |spec|
       spec.subspec 'Extensions' do |ext|
         ext.source_files = ['UIKit/SpecHelper/Extensions/*.{h,m}', 'UIKit/SpecHelper/UIKit+PivotalSpecHelper.h']
+        ext.dependency 'PivotalCoreKit/UIKit/SpecHelper/Helpers'
       end
 
       spec.subspec 'Matchers' do |match|


### PR DESCRIPTION
After my previous PR which added the `Helpers` directory within the UIKit SpecHelper, I realized that the `Extensions` sub-spec wasn't including those new files which it actually needs to build successfully.
