### PR TITLE
Adds support for UIAlertController

### DIFF
--- a/UIKit/Spec/Stubs/UIActionSheetSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIActionSheetSpec+Spec.mm
@@ -1,7 +1,6 @@
 #import "CDRSpecHelper.h"
 #import "UIActionSheet+Spec.h"
 
-
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
 

--- a/UIKit/Spec/Stubs/UIAlertActionSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertActionSpec+Spec.mm
@@ -1,0 +1,28 @@
+#import "CDRSpecHelper.h"
+#import "UIAlertAction+Spec.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(UIAlertAction_SpecSpec)
+
+describe(@"UIAlertAction (spec extensions)", ^{
+    __block UIAlertAction *action;
+    __block BOOL handled;
+
+    beforeEach(^{
+        handled = NO;
+        PCKAlertActionHandler handler = ^(UIAlertAction *){
+            handled = YES;
+        };
+
+        action = [UIAlertAction actionWithTitle:@"any title" style:UIAlertActionStyleDefault handler:handler];
+        action.handler(action);
+    });
+
+    it(@"should execute the handler", ^{
+        handled should be_truthy;
+    });
+});
+
+SPEC_END

--- a/UIKit/Spec/Stubs/UIAlertActionSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertActionSpec+Spec.mm
@@ -6,23 +6,27 @@ using namespace Cedar::Doubles;
 
 SPEC_BEGIN(UIAlertAction_SpecSpec)
 
-describe(@"UIAlertAction (spec extensions)", ^{
-    __block UIAlertAction *action;
-    __block BOOL handled;
+#ifdef __IPHONE_8_0
+if (NSClassFromString(@"UIAlertAction")) {
+    describe(@"UIAlertAction (spec extensions)", ^{
+        __block UIAlertAction *action;
+        __block BOOL handled;
 
-    beforeEach(^{
-        handled = NO;
-        PCKAlertActionHandler handler = ^(UIAlertAction *){
-            handled = YES;
-        };
+        beforeEach(^{
+            handled = NO;
+            PCKAlertActionHandler handler = ^(UIAlertAction *){
+                handled = YES;
+            };
 
-        action = [UIAlertAction actionWithTitle:@"any title" style:UIAlertActionStyleDefault handler:handler];
-        action.handler(action);
+            action = [UIAlertAction actionWithTitle:@"any title" style:UIAlertActionStyleDefault handler:handler];
+            action.handler(action);
+        });
+
+        it(@"should execute the handler", ^{
+            handled should be_truthy;
+        });
     });
-
-    it(@"should execute the handler", ^{
-        handled should be_truthy;
-    });
-});
+}
+#endif
 
 SPEC_END

--- a/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
@@ -101,6 +101,49 @@ describe(@"UIAlertController (spec extensions)", ^{
             itShouldBehaveLike(@"default cancel behavior");
         });
     });
+
+    describe(@"-dismissByTappingButtonWithTitle:", ^{
+        describe(@"UIAlertControllerStyleAlert", ^{
+            beforeEach(^{
+                alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                      message:@"Message"
+                                                               preferredStyle:UIAlertControllerStyleAlert];
+            });
+
+            context(@"when there is a button with a title", ^{
+                beforeEach(^{
+                    addCancelAction(alertController, nil);
+                    addDefaultAction(alertController, handler);
+                    [alertController dismissByTappingButtonWithTitle:@"Default"];
+                });
+
+                it(@"should tap the button", ^{
+                    handlerWasExecuted should be_truthy;
+                });
+            });
+
+            context(@"when there is not a button with a title", ^{
+                beforeEach(^{
+                    addDefaultAction(alertController, nil);
+                    addDefaultAction(alertController, handler);
+                });
+
+                it(@"should raise an exception stating a button with that title does not exist", ^{
+                    ^{ [alertController dismissByTappingButtonWithTitle:@"Non-existant"]; } should raise_exception;
+                });
+            });
+
+            context(@"when the button does not have an action", ^{
+                beforeEach(^{
+                    addDefaultAction(alertController, nil);
+                });
+
+                it(@"should not blow up", ^{
+                    ^{ [alertController dismissByTappingButtonWithTitle:@"Default"]; } should_not raise_exception;
+                });
+            });
+        });
+    });
 });
 
 SPEC_END

--- a/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
@@ -8,141 +8,146 @@ using namespace Cedar::Doubles;
 
 SPEC_BEGIN(UIAlertControllerSpec)
 
-describe(@"UIAlertController (spec extensions)", ^{
-    __block UIAlertController *alertController;
-    __block BOOL handlerWasExecuted;
-    __block PCKAlertActionHandler handler;
+#ifdef __IPHONE_8_0
+if (NSClassFromString(@"UIAlertController")) {
+    describe(@"UIAlertController (spec extensions)", ^{
+        __block UIAlertController *alertController;
+        __block BOOL handlerWasExecuted;
+        __block PCKAlertActionHandler handler;
 
-    void (^addCancelAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
-        [controller addAction:[UIAlertAction actionWithTitle:@"Cancel"
-                                                       style:UIAlertActionStyleCancel
-                                                     handler:handler]];
-    };
+        void (^addCancelAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
+            [controller addAction:[UIAlertAction actionWithTitle:@"Cancel"
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:handler]];
+        };
 
-    void (^addDefaultAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
-        [controller addAction:[UIAlertAction actionWithTitle:@"Default"
-                                                       style:UIAlertActionStyleDefault
-                                                     handler:handler]];
-    };
+        void (^addDefaultAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
+            [controller addAction:[UIAlertAction actionWithTitle:@"Default"
+                                                           style:UIAlertActionStyleDefault
+                                                         handler:handler]];
+        };
 
-    beforeEach(^{
-        handlerWasExecuted = NO;
-        handler = ^(UIAlertAction *) { handlerWasExecuted = YES; };
-    });
+        beforeEach(^{
+            handlerWasExecuted = NO;
+            handler = ^(UIAlertAction *) { handlerWasExecuted = YES; };
+        });
 
-    describe(@"-dismissByTappingCancelButton", ^{
-        sharedExamplesFor(@"default cancel behavior", ^(NSDictionary *sharedContext) {
-            describe(@"tapping the cancel button", ^{
-                context(@"containing a UIAlertActionStyleCancel button", ^{
+        describe(@"-dismissByTappingCancelButton", ^{
+            sharedExamplesFor(@"default cancel behavior", ^(NSDictionary *sharedContext) {
+                describe(@"tapping the cancel button", ^{
+                    context(@"containing a UIAlertActionStyleCancel button", ^{
+                        beforeEach(^{
+                            addCancelAction(alertController, handler);
+                            addDefaultAction(alertController, nil);
+
+                            [alertController dismissByTappingCancelButton];
+                        });
+
+                        it(@"should tap the cancel button regardless of where it is", ^{
+                            handlerWasExecuted should be_truthy;
+                        });
+                    });
+
+                    context(@"with a cancel button with no action", ^{
+                        beforeEach(^{
+                            addCancelAction(alertController, nil);
+                        });
+
+                        it(@"should not raise exception", ^{
+                            ^{ [alertController dismissByTappingCancelButton]; } should_not raise_exception;
+                        });
+                    });
+                });
+            });
+
+            describe(@"UIAlertControllerStyleAlert", ^{
+                beforeEach(^{
+                    alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                          message:@"Message"
+                                                                   preferredStyle:UIAlertControllerStyleAlert];
+                    addDefaultAction(alertController, nil);
+                });
+
+                context(@"without containing a UIAlertActionStyleCancel button", ^{
                     beforeEach(^{
-                        addCancelAction(alertController, handler);
-                        addDefaultAction(alertController, nil);
-
+                        addDefaultAction(alertController, handler);
                         [alertController dismissByTappingCancelButton];
                     });
 
-                    it(@"should tap the cancel button regardless of where it is", ^{
+                    it(@"should tap the last button", ^{
                         handlerWasExecuted should be_truthy;
                     });
                 });
 
-                context(@"with a cancel button with no action", ^{
+                itShouldBehaveLike(@"default cancel behavior");
+            });
+
+            describe(@"UIAlertControllerStyleActionSheet", ^{
+                beforeEach(^{
+                    alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                          message:@"Message"
+                                                                   preferredStyle:UIAlertControllerStyleActionSheet];
+                });
+
+                context(@"when a action sheet does not have a cancel button", ^{
+                    beforeEach(^{
+                        addDefaultAction(alertController, handler);
+                    });
+
+                    it(@"should blow up", ^{
+                        ^{ [alertController dismissByTappingCancelButton]; } should raise_exception;
+                    });
+                });
+
+                itShouldBehaveLike(@"default cancel behavior");
+            });
+        });
+
+        describe(@"-dismissByTappingButtonWithTitle:", ^{
+            describe(@"UIAlertControllerStyleAlert", ^{
+                beforeEach(^{
+                    alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                          message:@"Message"
+                                                                   preferredStyle:UIAlertControllerStyleAlert];
+                });
+
+                context(@"when there is a button with a title", ^{
                     beforeEach(^{
                         addCancelAction(alertController, nil);
+                        addDefaultAction(alertController, handler);
+                        [alertController dismissByTappingButtonWithTitle:@"Default"];
                     });
 
-                    it(@"should not raise exception", ^{
-                        ^{ [alertController dismissByTappingCancelButton]; } should_not raise_exception;
+                    it(@"should tap the button", ^{
+                        handlerWasExecuted should be_truthy;
+                    });
+                });
+
+                context(@"when there is not a button with a title", ^{
+                    beforeEach(^{
+                        addDefaultAction(alertController, nil);
+                        addDefaultAction(alertController, handler);
+                    });
+
+                    it(@"should raise an exception stating a button with that title does not exist", ^{
+                        ^{ [alertController dismissByTappingButtonWithTitle:@"Non-existant"]; } should raise_exception;
+                    });
+                });
+
+                context(@"when the button does not have an action", ^{
+                    beforeEach(^{
+                        addDefaultAction(alertController, nil);
+                    });
+
+                    it(@"should not blow up", ^{
+                        ^{ [alertController dismissByTappingButtonWithTitle:@"Default"]; } should_not raise_exception;
                     });
                 });
             });
         });
 
-        describe(@"UIAlertControllerStyleAlert", ^{
-            beforeEach(^{
-                alertController = [UIAlertController alertControllerWithTitle:@"Title"
-                                                                      message:@"Message"
-                                                               preferredStyle:UIAlertControllerStyleAlert];
-                addDefaultAction(alertController, nil);
-            });
-
-            context(@"without containing a UIAlertActionStyleCancel button", ^{
-                beforeEach(^{
-                    addDefaultAction(alertController, handler);
-                    [alertController dismissByTappingCancelButton];
-                });
-
-                it(@"should tap the last button", ^{
-                    handlerWasExecuted should be_truthy;
-                });
-            });
-
-            itShouldBehaveLike(@"default cancel behavior");
-        });
-
-        describe(@"UIAlertControllerStyleActionSheet", ^{
-            beforeEach(^{
-                alertController = [UIAlertController alertControllerWithTitle:@"Title"
-                                                                      message:@"Message"
-                                                               preferredStyle:UIAlertControllerStyleActionSheet];
-            });
-
-            context(@"when a action sheet does not have a cancel button", ^{
-                beforeEach(^{
-                    addDefaultAction(alertController, handler);
-                });
-
-                it(@"should blow up", ^{
-                    ^{ [alertController dismissByTappingCancelButton]; } should raise_exception;
-                });
-            });
-
-            itShouldBehaveLike(@"default cancel behavior");
-        });
     });
-
-    describe(@"-dismissByTappingButtonWithTitle:", ^{
-        describe(@"UIAlertControllerStyleAlert", ^{
-            beforeEach(^{
-                alertController = [UIAlertController alertControllerWithTitle:@"Title"
-                                                                      message:@"Message"
-                                                               preferredStyle:UIAlertControllerStyleAlert];
-            });
-
-            context(@"when there is a button with a title", ^{
-                beforeEach(^{
-                    addCancelAction(alertController, nil);
-                    addDefaultAction(alertController, handler);
-                    [alertController dismissByTappingButtonWithTitle:@"Default"];
-                });
-
-                it(@"should tap the button", ^{
-                    handlerWasExecuted should be_truthy;
-                });
-            });
-
-            context(@"when there is not a button with a title", ^{
-                beforeEach(^{
-                    addDefaultAction(alertController, nil);
-                    addDefaultAction(alertController, handler);
-                });
-
-                it(@"should raise an exception stating a button with that title does not exist", ^{
-                    ^{ [alertController dismissByTappingButtonWithTitle:@"Non-existant"]; } should raise_exception;
-                });
-            });
-
-            context(@"when the button does not have an action", ^{
-                beforeEach(^{
-                    addDefaultAction(alertController, nil);
-                });
-
-                it(@"should not blow up", ^{
-                    ^{ [alertController dismissByTappingButtonWithTitle:@"Default"]; } should_not raise_exception;
-                });
-            });
-        });
-    });
-});
+}
+#endif
 
 SPEC_END

--- a/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
@@ -1,0 +1,106 @@
+#import "CDRSpecHelper.h"
+#import "UIAlertController+Spec.h"
+#import "UIAlertView+Spec.h"
+#import "UIAlertAction+Spec.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(UIAlertControllerSpec)
+
+describe(@"UIAlertController (spec extensions)", ^{
+    __block UIAlertController *alertController;
+    __block BOOL handlerWasExecuted;
+    __block PCKAlertActionHandler handler;
+
+    void (^addCancelAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
+        [controller addAction:[UIAlertAction actionWithTitle:@"Cancel"
+                                                       style:UIAlertActionStyleCancel
+                                                     handler:handler]];
+    };
+
+    void (^addDefaultAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
+        [controller addAction:[UIAlertAction actionWithTitle:@"Default"
+                                                       style:UIAlertActionStyleDefault
+                                                     handler:handler]];
+    };
+
+    beforeEach(^{
+        handlerWasExecuted = NO;
+        handler = ^(UIAlertAction *) { handlerWasExecuted = YES; };
+    });
+
+    describe(@"-dismissByTappingCancelButton", ^{
+        sharedExamplesFor(@"default cancel behavior", ^(NSDictionary *sharedContext) {
+            describe(@"tapping the cancel button", ^{
+                context(@"containing a UIAlertActionStyleCancel button", ^{
+                    beforeEach(^{
+                        addCancelAction(alertController, handler);
+                        addDefaultAction(alertController, nil);
+
+                        [alertController dismissByTappingCancelButton];
+                    });
+
+                    it(@"should tap the cancel button regardless of where it is", ^{
+                        handlerWasExecuted should be_truthy;
+                    });
+                });
+
+                context(@"with a cancel button with no action", ^{
+                    beforeEach(^{
+                        addCancelAction(alertController, nil);
+                    });
+
+                    it(@"should not raise exception", ^{
+                        ^{ [alertController dismissByTappingCancelButton]; } should_not raise_exception;
+                    });
+                });
+            });
+        });
+
+        describe(@"UIAlertControllerStyleAlert", ^{
+            beforeEach(^{
+                alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                      message:@"Message"
+                                                               preferredStyle:UIAlertControllerStyleAlert];
+                addDefaultAction(alertController, nil);
+            });
+
+            context(@"without containing a UIAlertActionStyleCancel button", ^{
+                beforeEach(^{
+                    addDefaultAction(alertController, handler);
+                    [alertController dismissByTappingCancelButton];
+                });
+
+                it(@"should tap the last button", ^{
+                    handlerWasExecuted should be_truthy;
+                });
+            });
+
+            itShouldBehaveLike(@"default cancel behavior");
+        });
+
+        describe(@"UIAlertControllerStyleActionSheet", ^{
+            beforeEach(^{
+                alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                      message:@"Message"
+                                                               preferredStyle:UIAlertControllerStyleActionSheet];
+            });
+
+            context(@"when a action sheet does not have a cancel button", ^{
+                beforeEach(^{
+                    addDefaultAction(alertController, handler);
+                    [alertController dismissByTappingCancelButton];
+                });
+
+                it(@"should not tap the last button", ^{
+                    handlerWasExecuted should be_falsy;
+                });
+            });
+
+            itShouldBehaveLike(@"default cancel behavior");
+        });
+    });
+});
+
+SPEC_END

--- a/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
@@ -90,11 +90,10 @@ describe(@"UIAlertController (spec extensions)", ^{
             context(@"when a action sheet does not have a cancel button", ^{
                 beforeEach(^{
                     addDefaultAction(alertController, handler);
-                    [alertController dismissByTappingCancelButton];
                 });
 
-                it(@"should not tap the last button", ^{
-                    handlerWasExecuted should be_falsy;
+                it(@"should blow up", ^{
+                    ^{ [alertController dismissByTappingCancelButton]; } should raise_exception;
                 });
             });
 

--- a/UIKit/Spec/Stubs/UIAlertViewSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertViewSpec+Spec.mm
@@ -32,7 +32,7 @@ describe(@"UIAlertView (spec extensions)", ^{
                                       otherButtonTitles:@"OK", nil] autorelease];
     });
 
-    describe(@"Getting the current alert view with currentAlertView", ^{
+    describe(@"getting the current alert view with currentAlertView", ^{
         describe(@"when the alert view is not shown", ^{
             beforeEach(^{
                 expect(alertView).to_not(be_visible());

--- a/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+typedef void (^PCKAlertActionHandler)(UIAlertAction *action);
+
+@interface UIAlertAction (Spec)
+
+- (PCKAlertActionHandler)handler;
+
+@end

--- a/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+#ifdef __IPHONE_8_0
 typedef void (^PCKAlertActionHandler)(UIAlertAction *action);
 
 @interface UIAlertAction (Spec)
@@ -7,3 +8,4 @@ typedef void (^PCKAlertActionHandler)(UIAlertAction *action);
 - (PCKAlertActionHandler)handler;
 
 @end
+#endif

--- a/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.m
@@ -1,0 +1,30 @@
+#import "UIAlertAction+Spec.h"
+#import "PCKMethodRedirector.h"
+#import <objc/objc-runtime.h>
+
+static char * kHandlerKey;
+
+@interface UIAlertAction (SpecPrivate)
++ (instancetype)original_actionWithTitle:(NSString *)title style:(UIAlertActionStyle)style handler:(void (^)(UIAlertAction *))handler;
+@end
+
+@implementation UIAlertAction (Spec)
+
++ (void)load {
+    [PCKMethodRedirector redirectSelector:@selector(actionWithTitle:style:handler:)
+                                 forClass:objc_getMetaClass(class_getName([self class]))
+                                       to:@selector(_actionWithTitle:style:handler:)
+                            andRenameItTo:@selector(original_actionWithTitle:style:handler:)];
+}
+
++ (instancetype)_actionWithTitle:(NSString *)title style:(UIAlertActionStyle)style handler:(void (^)(UIAlertAction *))handler {
+    UIAlertAction *action = [self original_actionWithTitle:title style:style handler:handler];
+    objc_setAssociatedObject(action, &kHandlerKey, handler, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    return action;
+}
+
+- (PCKAlertActionHandler)handler {
+    return objc_getAssociatedObject(self, &kHandlerKey);
+}
+
+@end

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface UIAlertController (Spec)
+
+- (void)dismissByTappingCancelButton;
+
+@end

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
@@ -1,8 +1,10 @@
 #import <UIKit/UIKit.h>
 
+#ifdef __IPHONE_8_0
 @interface UIAlertController (Spec)
 
 - (void)dismissByTappingCancelButton;
 - (void)dismissByTappingButtonWithTitle:(NSString *)title;
 
 @end
+#endif

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
@@ -3,5 +3,6 @@
 @interface UIAlertController (Spec)
 
 - (void)dismissByTappingCancelButton;
+- (void)dismissByTappingButtonWithTitle:(NSString *)title;
 
 @end

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
@@ -1,0 +1,28 @@
+#import "UIAlertController+Spec.h"
+#import "UIAlertAction+Spec.h"
+
+@implementation UIAlertController (Spec)
+
+- (void)dismissByTappingCancelButton {
+    UIAlertAction *cancelAction = [self cancelAction];
+    if (cancelAction.handler) {
+        cancelAction.handler(cancelAction);
+    }
+}
+
+#pragma mark - Private
+
+- (UIAlertAction *)cancelAction {
+    NSPredicate *cancelPredicate = [NSPredicate predicateWithBlock:^BOOL(UIAlertAction *action, NSDictionary *bindings) {
+        return action.style == UIAlertActionStyleCancel;
+    }];
+
+    UIAlertAction *cancelAction = [[self.actions filteredArrayUsingPredicate:cancelPredicate] lastObject];
+    if (self.preferredStyle == UIAlertControllerStyleActionSheet) {
+        return cancelAction;
+    } else {
+        return cancelAction ? cancelAction : self.actions.lastObject;
+    }
+}
+
+@end

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
@@ -10,6 +10,13 @@
     }
 }
 
+- (void)dismissByTappingButtonWithTitle:(NSString *)title {
+    UIAlertAction *action = [self actionWithButtonTitle:title];
+    if (action.handler) {
+        action.handler(action);
+    }
+}
+
 #pragma mark - Private
 
 - (UIAlertAction *)cancelAction {
@@ -23,6 +30,13 @@
     } else {
         return cancelAction ? cancelAction : self.actions.lastObject;
     }
+}
+
+- (UIAlertAction *)actionWithButtonTitle:(NSString *)title {
+    NSArray *buttonTitles = [self.actions valueForKey:@"title"];
+    NSUInteger buttonIndex = [buttonTitles indexOfObject:title];
+    NSAssert((buttonIndex != NSNotFound), @"UIAlertController does not have a button titled '%@' -- current button titles are %@", title, buttonTitles);
+    return self.actions[buttonIndex];
 }
 
 @end

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
@@ -26,6 +26,7 @@
 
     UIAlertAction *cancelAction = [[self.actions filteredArrayUsingPredicate:cancelPredicate] lastObject];
     if (self.preferredStyle == UIAlertControllerStyleActionSheet) {
+        NSAssert(cancelAction, @"UIAlertController does not have a cancel button");
         return cancelAction;
     } else {
         return cancelAction ? cancelAction : self.actions.lastObject;

--- a/UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h
+++ b/UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h
@@ -5,3 +5,4 @@
 #import "UIImagePickerController+Spec.h"
 #import "UIGestureRecognizer+Spec.h"
 #import "UIAlertAction+Spec.h"
+#import "UIAlertController+Spec.h"

--- a/UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h
+++ b/UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h
@@ -4,3 +4,4 @@
 #import "UITabBarController+Spec.h"
 #import "UIImagePickerController+Spec.h"
 #import "UIGestureRecognizer+Spec.h"
+#import "UIAlertAction+Spec.h"

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		34BDAC7F19A433510085B45A /* UICollectionReusableView+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 34BDAC7519A42C5F0085B45A /* UICollectionReusableView+Spec.h */; };
 		8487257E19013F6400288770 /* UIActivityViewController+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8487257219013F5F00288770 /* UIActivityViewController+Spec.m */; };
 		84C62A78190141DD00DF2982 /* UIActivityViewControllerSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		AE062BD01A43240500AF8D33 /* UIAlertActionSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE062BCE1A4323CF00AF8D33 /* UIAlertActionSpec+Spec.mm */; };
+		AE062BD11A43241B00AF8D33 /* UIAlertAction+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE062BC01A4323A800AF8D33 /* UIAlertAction+Spec.m */; };
 		AE118AA418D6B57000C90D6B /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE118AA318D6B57000C90D6B /* SenTestingKit.framework */; };
 		AE118AA718D6B57000C90D6B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AEBCCBE7168B97DD0056EE83 /* Foundation.framework */; };
 		AE118AC218D6B63900C90D6B /* BundleSpecLoader.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE118AC118D6B63900C90D6B /* BundleSpecLoader.mm */; };
@@ -373,6 +375,9 @@
 		8487257119013F5F00288770 /* UIActivityViewController+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIActivityViewController+Spec.h"; sourceTree = "<group>"; };
 		8487257219013F5F00288770 /* UIActivityViewController+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIActivityViewController+Spec.m"; sourceTree = "<group>"; };
 		8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIActivityViewControllerSpec+Spec.mm"; sourceTree = "<group>"; };
+		AE062BBF1A4323A800AF8D33 /* UIAlertAction+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAlertAction+Spec.h"; sourceTree = "<group>"; };
+		AE062BC01A4323A800AF8D33 /* UIAlertAction+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIAlertAction+Spec.m"; sourceTree = "<group>"; };
+		AE062BCE1A4323CF00AF8D33 /* UIAlertActionSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIAlertActionSpec+Spec.mm"; sourceTree = "<group>"; };
 		AE118AA218D6B57000C90D6B /* UIKit-StaticLibSpecBundle.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UIKit-StaticLibSpecBundle.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE118AA318D6B57000C90D6B /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		AE118AC118D6B63900C90D6B /* BundleSpecLoader.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BundleSpecLoader.mm; sourceTree = "<group>"; };
@@ -789,6 +794,8 @@
 				AEC40CAF174C22BD00474D2D /* UIActionSheet+Spec.m */,
 				8487257119013F5F00288770 /* UIActivityViewController+Spec.h */,
 				8487257219013F5F00288770 /* UIActivityViewController+Spec.m */,
+				AE062BBF1A4323A800AF8D33 /* UIAlertAction+Spec.h */,
+				AE062BC01A4323A800AF8D33 /* UIAlertAction+Spec.m */,
 				AEC40CB0174C22BD00474D2D /* UIAlertView+Spec.h */,
 				AEC40CB1174C22BD00474D2D /* UIAlertView+Spec.m */,
 				DE99C78703C6C6CA8C0465B3 /* UIGestureRecognizer+Spec.h */,
@@ -814,6 +821,7 @@
 			children = (
 				AEF67CE018CA436600C221D1 /* UIActionSheetSpec+Spec.mm */,
 				8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */,
+				AE062BCE1A4323CF00AF8D33 /* UIAlertActionSpec+Spec.mm */,
 				AEC40CBE174C24CF00474D2D /* UIAlertViewSpec+Spec.mm */,
 				AEEECC32181F33F5006B52CD /* UIImagePickerControllerSpec+Spec.mm */,
 				AEEDC56719FAC2E2004AFFE9 /* UINavigationControllerSpec+Spec.mm */,
@@ -1221,6 +1229,8 @@
 				FA91AA9E1867260400925A6B /* NSString+PivotalCoreKit_UIKitSpec.mm in Sources */,
 				AE7B279617CFD67600904F64 /* UIViewControllerSpec+Spec.mm in Sources */,
 				AE95306A1832EE9300C802E9 /* UIViewSpec+Spec.mm in Sources */,
+				AE062BD01A43240500AF8D33 /* UIAlertActionSpec+Spec.mm in Sources */,
+				AE062BD11A43241B00AF8D33 /* UIAlertAction+Spec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -785,8 +785,6 @@
 		AEC40C95174C21AC00474D2D /* Stubs */ = {
 			isa = PBXGroup;
 			children = (
-				AECB46AA1A3FBA9E00398720 /* UIView+StubbedGestureRecognizers.h */,
-				AECB46AB1A3FBA9E00398720 /* UIView+StubbedGestureRecognizers.m */,
 				AEC40CAE174C22BD00474D2D /* UIActionSheet+Spec.h */,
 				AEC40CAF174C22BD00474D2D /* UIActionSheet+Spec.m */,
 				8487257119013F5F00288770 /* UIActivityViewController+Spec.h */,
@@ -802,6 +800,8 @@
 				AEB6662B18C6681A00B09C00 /* UIPopoverController+Spec.m */,
 				AEE0B69518A3572C0007A9D0 /* UIView+StubbedAnimation.h */,
 				AE89900218071F3A00DDB948 /* UIView+StubbedAnimation.m */,
+				AECB46AA1A3FBA9E00398720 /* UIView+StubbedGestureRecognizers.h */,
+				AECB46AB1A3FBA9E00398720 /* UIView+StubbedGestureRecognizers.m */,
 				AEC40CB2174C22BD00474D2D /* UIViewController+Spec.m */,
 				AEC40CB3174C22BD00474D2D /* UIWebView+Spec.h */,
 				AEC40CB4174C22BD00474D2D /* UIWebView+Spec.m */,
@@ -813,6 +813,7 @@
 			isa = PBXGroup;
 			children = (
 				AEF67CE018CA436600C221D1 /* UIActionSheetSpec+Spec.mm */,
+				8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */,
 				AEC40CBE174C24CF00474D2D /* UIAlertViewSpec+Spec.mm */,
 				AEEECC32181F33F5006B52CD /* UIImagePickerControllerSpec+Spec.mm */,
 				AEEDC56719FAC2E2004AFFE9 /* UINavigationControllerSpec+Spec.mm */,
@@ -820,7 +821,6 @@
 				AE7B279517CFD67600904F64 /* UIViewControllerSpec+Spec.mm */,
 				AE898FF718071E2B00DDB948 /* UIViewSpec+StubbedAnimations.mm */,
 				AEC40CBF174C24CF00474D2D /* UIWebViewSpec+Spec.mm */,
-				8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */,
 			);
 			path = Stubs;
 			sourceTree = "<group>";

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -73,6 +73,9 @@
 		AE3B43901A30D95200265154 /* PCKMethodRedirector.m in Sources */ = {isa = PBXBuildFile; fileRef = AEF5D45C1A030D2E00C4DC3D /* PCKMethodRedirector.m */; };
 		AE53E2EC18075A810037C32E /* UIWindow+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE53E2EB18075A810037C32E /* UIWindow+Spec.m */; };
 		AE53E2F618075B080037C32E /* UIWindowSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE53E2F518075B080037C32E /* UIWindowSpec+Spec.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		AE61C1211A40B5BE00C97245 /* UIAlertControllerSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE61C11F1A40B59000C97245 /* UIAlertControllerSpec+Spec.mm */; };
+		AE61C13F1A40B98900C97245 /* UIAlertController+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE61C1301A40B95E00C97245 /* UIAlertController+Spec.h */; };
+		AE61C1401A40B98E00C97245 /* UIAlertController+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE61C1311A40B95E00C97245 /* UIAlertController+Spec.m */; };
 		AE7B279617CFD67600904F64 /* UIViewControllerSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE7B279517CFD67600904F64 /* UIViewControllerSpec+Spec.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		AE7CE69319FACA8B007B008F /* NavigationStackExample.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE7CE69219FACA84007B008F /* NavigationStackExample.storyboard */; };
 		AE86BD42179C7C910057DEAE /* UITabBarController+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE86BD40179C7C910057DEAE /* UITabBarController+Spec.h */; };
@@ -326,6 +329,7 @@
 				AEC40CCB174C292600474D2D /* UIWebView+Spec.h in Copy headers to framework */,
 				AECB46BA1A3FBB6C00398720 /* UIGestureRecognizer+Spec.h in Copy headers to framework */,
 				AEF5D45D1A030D2E00C4DC3D /* PCKMethodRedirector.h in Copy headers to framework */,
+				AE61C13F1A40B98900C97245 /* UIAlertController+Spec.h in Copy headers to framework */,
 				AE244D4319077EEB00ED96E9 /* UIActivityViewController+Spec.h in Copy headers to framework */,
 				AEC40CCC174C292600474D2D /* UIKit+PivotalSpecHelperStubs.h in Copy headers to framework */,
 				AEB6662C18C6681A00B09C00 /* UIPopoverController+Spec.h in Copy headers to framework */,
@@ -393,6 +397,9 @@
 		AE53E2EA18075A810037C32E /* UIWindow+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIWindow+Spec.h"; sourceTree = "<group>"; };
 		AE53E2EB18075A810037C32E /* UIWindow+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIWindow+Spec.m"; sourceTree = "<group>"; };
 		AE53E2F518075B080037C32E /* UIWindowSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIWindowSpec+Spec.mm"; sourceTree = "<group>"; };
+		AE61C11F1A40B59000C97245 /* UIAlertControllerSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIAlertControllerSpec+Spec.mm"; sourceTree = "<group>"; };
+		AE61C1301A40B95E00C97245 /* UIAlertController+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAlertController+Spec.h"; sourceTree = "<group>"; };
+		AE61C1311A40B95E00C97245 /* UIAlertController+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIAlertController+Spec.m"; sourceTree = "<group>"; };
 		AE7B279517CFD67600904F64 /* UIViewControllerSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIViewControllerSpec+Spec.mm"; sourceTree = "<group>"; };
 		AE7CE69219FACA84007B008F /* NavigationStackExample.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = NavigationStackExample.storyboard; sourceTree = "<group>"; };
 		AE86BD40179C7C910057DEAE /* UITabBarController+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBarController+Spec.h"; sourceTree = "<group>"; };
@@ -796,6 +803,8 @@
 				8487257219013F5F00288770 /* UIActivityViewController+Spec.m */,
 				AE062BBF1A4323A800AF8D33 /* UIAlertAction+Spec.h */,
 				AE062BC01A4323A800AF8D33 /* UIAlertAction+Spec.m */,
+				AE61C1301A40B95E00C97245 /* UIAlertController+Spec.h */,
+				AE61C1311A40B95E00C97245 /* UIAlertController+Spec.m */,
 				AEC40CB0174C22BD00474D2D /* UIAlertView+Spec.h */,
 				AEC40CB1174C22BD00474D2D /* UIAlertView+Spec.m */,
 				DE99C78703C6C6CA8C0465B3 /* UIGestureRecognizer+Spec.h */,
@@ -822,6 +831,7 @@
 				AEF67CE018CA436600C221D1 /* UIActionSheetSpec+Spec.mm */,
 				8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */,
 				AE062BCE1A4323CF00AF8D33 /* UIAlertActionSpec+Spec.mm */,
+				AE61C11F1A40B59000C97245 /* UIAlertControllerSpec+Spec.mm */,
 				AEC40CBE174C24CF00474D2D /* UIAlertViewSpec+Spec.mm */,
 				AEEECC32181F33F5006B52CD /* UIImagePickerControllerSpec+Spec.mm */,
 				AEEDC56719FAC2E2004AFFE9 /* UINavigationControllerSpec+Spec.mm */,
@@ -1214,6 +1224,7 @@
 				AE3847AD168BA0E300C99B55 /* AWebViewController.m in Sources */,
 				AEC6D7FE16963F3500E10C7B /* UIControlSpec+Spec.mm in Sources */,
 				AE898FF818071E2B00DDB948 /* UIViewSpec+StubbedAnimations.mm in Sources */,
+				AE61C1211A40B5BE00C97245 /* UIAlertControllerSpec+Spec.mm in Sources */,
 				22601B5916BA209F00A807CB /* UISliderSpec+Spec.mm in Sources */,
 				B8C62E6F16BC04230009CDAD /* UIBarButtonItemSpec+Spec.mm in Sources */,
 				AEDABBBB18EA214A004E6626 /* ChildViewController.m in Sources */,
@@ -1267,6 +1278,7 @@
 				AEC40CB8174C22BD00474D2D /* UIWebView+Spec.m in Sources */,
 				8487257E19013F6400288770 /* UIActivityViewController+Spec.m in Sources */,
 				AE3B43901A30D95200265154 /* PCKMethodRedirector.m in Sources */,
+				AE61C1401A40B98E00C97245 /* UIAlertController+Spec.m in Sources */,
 				AE86BD43179C7C910057DEAE /* UITabBarController+Spec.m in Sources */,
 				DE99CA8267EEACF8EE9A941F /* UIGestureRecognizer+Spec.m in Sources */,
 			);


### PR DESCRIPTION
Exposes private `-handler` to `UIAlertAction` in spec. Adds `-dismissByTappingCancelButton` and -`dismissByTappingButtonWithTitle:` to `UIAlertController`.

The API follows a similar pattern to PCK's existing `UIActionSheet` but renames to be closer to Apple's guidelines. We deduced the behavior of `UIAlertController` two styles by creating an example project and experimenting with different combinations of button styles.

Note that the class method, `[UIAlertView currentAlertView]` and `[UIActionSheet currentActionSheet]`, will not return a `UIAlertController`, use `UIViewController`'s `-alertController`. 