### PR TITLE
Deprecate swipe for StubbedGestureRecognizers

### DIFF
--- a/UIKit/Spec/Extensions/UIViewSpec+Spec.mm
+++ b/UIKit/Spec/Extensions/UIViewSpec+Spec.mm
@@ -55,7 +55,10 @@ describe(@"UIView+Spec", ^{
         });
 
         it(@"should dispatch swipe events when you call -swipe", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
             [view swipe];
+#pragma clang diagnostic pop
 
             target should have_received(@selector(hello));
             otherTarget should_not have_received(@selector(hello));

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedGestureRecognizers.h
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedGestureRecognizers.h
@@ -3,7 +3,8 @@
 @interface UIView (StubbedGestureRecognizers)
 
 - (void)tap;
-- (void)swipe;
+/*! @abstract Use swipeInDirection: instead. */
+- (void)swipe DEPRECATED_ATTRIBUTE;
 - (void)swipeInDirection:(UISwipeGestureRecognizerDirection)swipeDirection;
 - (void)pinch;
 


### PR DESCRIPTION
Deprecates `StubbedGestureRecognizers `'s `-swipe` and informs developer to use `-swipeInDirection:` instead.