### PR TITLE
Use presence of error rather than presence of value checking in Error monads

### DIFF
--- a/Foundation/Core/Monads/PCKCompletionHandler.m
+++ b/Foundation/Core/Monads/PCKCompletionHandler.m
@@ -31,11 +31,14 @@
 {
     NSParameterAssert(completionHandler);
     return [PCKCompletionHandler completionHandlerWithBlock:^id(id o, NSURLResponse *response, NSError **pError) {
-        id result = [completionHandler callWith:o response:response error:nil outError:pError];
-        if (result) {
+        NSError *error = nil;
+        id result = [completionHandler callWith:o response:response error:nil outError:&error];
+        if (!error) {
             return [self callWith:result response:response error:nil outError:pError];
+        } else if (pError) {
+            *pError = error;
         }
-        return nil;
+        return result;
     }];
 }
 
@@ -49,8 +52,8 @@
     if (error) {
         if (outError) {
             *outError = error;
-            return nil;
         }
+        return value;
     }
     return _block(value, response, outError);
 }

--- a/Foundation/Core/Monads/PCKErrorBlock.m
+++ b/Foundation/Core/Monads/PCKErrorBlock.m
@@ -33,11 +33,14 @@
 {
     NSParameterAssert(errorBlock);
     return [PCKErrorBlock errorWithBlock:^id(id success, NSError **errorPtr) {
-        id result = [errorBlock callWithSuccess:success error:errorPtr];
-        if (result) {
+        NSError *error = nil;
+        id result = [errorBlock callWithSuccess:success error:&error];
+        if (!error) {
             return [self callWithSuccess:result error:errorPtr];
+        } else if (errorPtr) {
+            *errorPtr = error;
         }
-        return nil;
+        return result;
     }];
 }
 

--- a/Foundation/Spec/Monads/PCKCompletionHandlerSpec.mm
+++ b/Foundation/Spec/Monads/PCKCompletionHandlerSpec.mm
@@ -45,6 +45,12 @@ describe(@"PCKCompletionHandler", ^{
             error.code should equal(2);
         });
 
+        it(@"does not invoke the block when called with failure ignoring errors", ^{
+            [[PCKCompletionHandler completionHandlerWithBlock:^id(id o, NSURLResponse *response, NSError **pError) {
+                return @2;
+            }] callWith:@1 response:nil error:[NSError errorWithDomain:NSCocoaErrorDomain code:2 userInfo:nil] outError:NULL] should equal(@1);
+        });
+
         describe(@"composing and invoking functions", ^{
             __block PCKCompletionHandler *composed;
             beforeEach(^{


### PR DESCRIPTION
Use the presence of errors rather than nil checking results when chaining Error Monads (PCKErrorBlock and PCKCompletionHandler). This better follows the C convention for functions that return errors through a pass by reference argument.

This represents a change to the error monad api, as a failed "call" is no longer guaranteed to return nil.  However, since error blocks are no longer required to return a non-nil value, the PCKErrorBlock can act as MaybeError block (Try<Option<T>>) if error blocks are written as such.  This also opens the door for a PCKMaybeErrorBlock to be written if desired.