### PR TITLE
Dynamic notification category controllers

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,6 +1,6 @@
 ## HEAD
 
-## 0.2.2 (in progress)
+## 0.2.2
 
   * Adds support for testing wiring of WatchKit apps in Cedar/XCTest/etc.
 

--- a/Foundation/Core/Monads/PCKCompletionHandler.m
+++ b/Foundation/Core/Monads/PCKCompletionHandler.m
@@ -31,11 +31,14 @@
 {
     NSParameterAssert(completionHandler);
     return [PCKCompletionHandler completionHandlerWithBlock:^id(id o, NSURLResponse *response, NSError **pError) {
-        id result = [completionHandler callWith:o response:response error:nil outError:pError];
-        if (result) {
+        NSError *error = nil;
+        id result = [completionHandler callWith:o response:response error:nil outError:&error];
+        if (!error) {
             return [self callWith:result response:response error:nil outError:pError];
+        } else if (pError) {
+            *pError = error;
         }
-        return nil;
+        return result;
     }];
 }
 
@@ -49,8 +52,8 @@
     if (error) {
         if (outError) {
             *outError = error;
-            return nil;
         }
+        return value;
     }
     return _block(value, response, outError);
 }

--- a/Foundation/Core/Monads/PCKErrorBlock.m
+++ b/Foundation/Core/Monads/PCKErrorBlock.m
@@ -33,11 +33,14 @@
 {
     NSParameterAssert(errorBlock);
     return [PCKErrorBlock errorWithBlock:^id(id success, NSError **errorPtr) {
-        id result = [errorBlock callWithSuccess:success error:errorPtr];
-        if (result) {
+        NSError *error = nil;
+        id result = [errorBlock callWithSuccess:success error:&error];
+        if (!error) {
             return [self callWithSuccess:result error:errorPtr];
+        } else if (errorPtr) {
+            *errorPtr = error;
         }
-        return nil;
+        return result;
     }];
 }
 

--- a/Foundation/Spec/Monads/PCKCompletionHandlerSpec.mm
+++ b/Foundation/Spec/Monads/PCKCompletionHandlerSpec.mm
@@ -45,6 +45,12 @@ describe(@"PCKCompletionHandler", ^{
             error.code should equal(2);
         });
 
+        it(@"does not invoke the block when called with failure ignoring errors", ^{
+            [[PCKCompletionHandler completionHandlerWithBlock:^id(id o, NSURLResponse *response, NSError **pError) {
+                return @2;
+            }] callWith:@1 response:nil error:[NSError errorWithDomain:NSCocoaErrorDomain code:2 userInfo:nil] outError:NULL] should equal(@1);
+        });
+
         describe(@"composing and invoking functions", ^{
             __block PCKCompletionHandler *composed;
             beforeEach(^{

--- a/PivotalCoreKit.podspec
+++ b/PivotalCoreKit.podspec
@@ -109,10 +109,8 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'WatchKit' do |watchkit|
-    watchkit.subspec 'WatchKit' do |h|
-      h.subspec 'Base' do |base|
-        base.source_files = 'WatchKit/WatchKit/*.{h,m}'
-      end
+    watchkit.subspec 'WatchKit' do |child_watchkit|
+      child_watchkit.source_files = 'WatchKit/WatchKit/*.{h,m}'
     end
   end
 end

--- a/PivotalCoreKit.podspec
+++ b/PivotalCoreKit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'Shared library and test code for iOS projects.'
   s.homepage = 'https://github.com/pivotal/PivotalCoreKit'
   s.author   = { 'Pivotal Labs' => 'http://pivotallabs.com' }
-  s.source   = { :git => 'https://github.com/pivotal/PivotalCoreKit.git', :tag => '0.2.2' }
+  s.source   = { :git => 'https://github.com/pivotal/PivotalCoreKit.git', :tag => 'v0.2.2' }
   s.platform = :ios, '6.0'
   s.requires_arc = false
 

--- a/PivotalCoreKit.podspec
+++ b/PivotalCoreKit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'Shared library and test code for iOS projects.'
   s.homepage = 'https://github.com/pivotal/PivotalCoreKit'
   s.author   = { 'Pivotal Labs' => 'http://pivotallabs.com' }
-  s.source   = { :git => 'https://github.com/pivotal/PivotalCoreKit.git' }
+  s.source   = { :git => 'https://github.com/pivotal/PivotalCoreKit.git', :tag => '0.2.2' }
   s.platform = :ios, '6.0'
   s.requires_arc = false
 

--- a/UIKit/Spec/Extensions/UIViewSpec+Spec.mm
+++ b/UIKit/Spec/Extensions/UIViewSpec+Spec.mm
@@ -55,7 +55,10 @@ describe(@"UIView+Spec", ^{
         });
 
         it(@"should dispatch swipe events when you call -swipe", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
             [view swipe];
+#pragma clang diagnostic pop
 
             target should have_received(@selector(hello));
             otherTarget should_not have_received(@selector(hello));

--- a/UIKit/Spec/Stubs/UIActionSheetSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIActionSheetSpec+Spec.mm
@@ -1,7 +1,6 @@
 #import "CDRSpecHelper.h"
 #import "UIActionSheet+Spec.h"
 
-
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
 

--- a/UIKit/Spec/Stubs/UIAlertActionSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertActionSpec+Spec.mm
@@ -1,0 +1,28 @@
+#import "CDRSpecHelper.h"
+#import "UIAlertAction+Spec.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(UIAlertAction_SpecSpec)
+
+describe(@"UIAlertAction (spec extensions)", ^{
+    __block UIAlertAction *action;
+    __block BOOL handled;
+
+    beforeEach(^{
+        handled = NO;
+        PCKAlertActionHandler handler = ^(UIAlertAction *){
+            handled = YES;
+        };
+
+        action = [UIAlertAction actionWithTitle:@"any title" style:UIAlertActionStyleDefault handler:handler];
+        action.handler(action);
+    });
+
+    it(@"should execute the handler", ^{
+        handled should be_truthy;
+    });
+});
+
+SPEC_END

--- a/UIKit/Spec/Stubs/UIAlertActionSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertActionSpec+Spec.mm
@@ -6,7 +6,8 @@ using namespace Cedar::Doubles;
 
 SPEC_BEGIN(UIAlertAction_SpecSpec)
 
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_8_0
+
 if (NSClassFromString(@"UIAlertAction")) {
     describe(@"UIAlertAction (spec extensions)", ^{
         __block UIAlertAction *action;

--- a/UIKit/Spec/Stubs/UIAlertActionSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertActionSpec+Spec.mm
@@ -6,23 +6,27 @@ using namespace Cedar::Doubles;
 
 SPEC_BEGIN(UIAlertAction_SpecSpec)
 
-describe(@"UIAlertAction (spec extensions)", ^{
-    __block UIAlertAction *action;
-    __block BOOL handled;
+#ifdef __IPHONE_8_0
+if (NSClassFromString(@"UIAlertAction")) {
+    describe(@"UIAlertAction (spec extensions)", ^{
+        __block UIAlertAction *action;
+        __block BOOL handled;
 
-    beforeEach(^{
-        handled = NO;
-        PCKAlertActionHandler handler = ^(UIAlertAction *){
-            handled = YES;
-        };
+        beforeEach(^{
+            handled = NO;
+            PCKAlertActionHandler handler = ^(UIAlertAction *){
+                handled = YES;
+            };
 
-        action = [UIAlertAction actionWithTitle:@"any title" style:UIAlertActionStyleDefault handler:handler];
-        action.handler(action);
+            action = [UIAlertAction actionWithTitle:@"any title" style:UIAlertActionStyleDefault handler:handler];
+            action.handler(action);
+        });
+
+        it(@"should execute the handler", ^{
+            handled should be_truthy;
+        });
     });
-
-    it(@"should execute the handler", ^{
-        handled should be_truthy;
-    });
-});
+}
+#endif
 
 SPEC_END

--- a/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
@@ -101,6 +101,49 @@ describe(@"UIAlertController (spec extensions)", ^{
             itShouldBehaveLike(@"default cancel behavior");
         });
     });
+
+    describe(@"-dismissByTappingButtonWithTitle:", ^{
+        describe(@"UIAlertControllerStyleAlert", ^{
+            beforeEach(^{
+                alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                      message:@"Message"
+                                                               preferredStyle:UIAlertControllerStyleAlert];
+            });
+
+            context(@"when there is a button with a title", ^{
+                beforeEach(^{
+                    addCancelAction(alertController, nil);
+                    addDefaultAction(alertController, handler);
+                    [alertController dismissByTappingButtonWithTitle:@"Default"];
+                });
+
+                it(@"should tap the button", ^{
+                    handlerWasExecuted should be_truthy;
+                });
+            });
+
+            context(@"when there is not a button with a title", ^{
+                beforeEach(^{
+                    addDefaultAction(alertController, nil);
+                    addDefaultAction(alertController, handler);
+                });
+
+                it(@"should raise an exception stating a button with that title does not exist", ^{
+                    ^{ [alertController dismissByTappingButtonWithTitle:@"Non-existant"]; } should raise_exception;
+                });
+            });
+
+            context(@"when the button does not have an action", ^{
+                beforeEach(^{
+                    addDefaultAction(alertController, nil);
+                });
+
+                it(@"should not blow up", ^{
+                    ^{ [alertController dismissByTappingButtonWithTitle:@"Default"]; } should_not raise_exception;
+                });
+            });
+        });
+    });
 });
 
 SPEC_END

--- a/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
@@ -8,141 +8,146 @@ using namespace Cedar::Doubles;
 
 SPEC_BEGIN(UIAlertControllerSpec)
 
-describe(@"UIAlertController (spec extensions)", ^{
-    __block UIAlertController *alertController;
-    __block BOOL handlerWasExecuted;
-    __block PCKAlertActionHandler handler;
+#ifdef __IPHONE_8_0
+if (NSClassFromString(@"UIAlertController")) {
+    describe(@"UIAlertController (spec extensions)", ^{
+        __block UIAlertController *alertController;
+        __block BOOL handlerWasExecuted;
+        __block PCKAlertActionHandler handler;
 
-    void (^addCancelAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
-        [controller addAction:[UIAlertAction actionWithTitle:@"Cancel"
-                                                       style:UIAlertActionStyleCancel
-                                                     handler:handler]];
-    };
+        void (^addCancelAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
+            [controller addAction:[UIAlertAction actionWithTitle:@"Cancel"
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:handler]];
+        };
 
-    void (^addDefaultAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
-        [controller addAction:[UIAlertAction actionWithTitle:@"Default"
-                                                       style:UIAlertActionStyleDefault
-                                                     handler:handler]];
-    };
+        void (^addDefaultAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
+            [controller addAction:[UIAlertAction actionWithTitle:@"Default"
+                                                           style:UIAlertActionStyleDefault
+                                                         handler:handler]];
+        };
 
-    beforeEach(^{
-        handlerWasExecuted = NO;
-        handler = ^(UIAlertAction *) { handlerWasExecuted = YES; };
-    });
+        beforeEach(^{
+            handlerWasExecuted = NO;
+            handler = ^(UIAlertAction *) { handlerWasExecuted = YES; };
+        });
 
-    describe(@"-dismissByTappingCancelButton", ^{
-        sharedExamplesFor(@"default cancel behavior", ^(NSDictionary *sharedContext) {
-            describe(@"tapping the cancel button", ^{
-                context(@"containing a UIAlertActionStyleCancel button", ^{
+        describe(@"-dismissByTappingCancelButton", ^{
+            sharedExamplesFor(@"default cancel behavior", ^(NSDictionary *sharedContext) {
+                describe(@"tapping the cancel button", ^{
+                    context(@"containing a UIAlertActionStyleCancel button", ^{
+                        beforeEach(^{
+                            addCancelAction(alertController, handler);
+                            addDefaultAction(alertController, nil);
+
+                            [alertController dismissByTappingCancelButton];
+                        });
+
+                        it(@"should tap the cancel button regardless of where it is", ^{
+                            handlerWasExecuted should be_truthy;
+                        });
+                    });
+
+                    context(@"with a cancel button with no action", ^{
+                        beforeEach(^{
+                            addCancelAction(alertController, nil);
+                        });
+
+                        it(@"should not raise exception", ^{
+                            ^{ [alertController dismissByTappingCancelButton]; } should_not raise_exception;
+                        });
+                    });
+                });
+            });
+
+            describe(@"UIAlertControllerStyleAlert", ^{
+                beforeEach(^{
+                    alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                          message:@"Message"
+                                                                   preferredStyle:UIAlertControllerStyleAlert];
+                    addDefaultAction(alertController, nil);
+                });
+
+                context(@"without containing a UIAlertActionStyleCancel button", ^{
                     beforeEach(^{
-                        addCancelAction(alertController, handler);
-                        addDefaultAction(alertController, nil);
-
+                        addDefaultAction(alertController, handler);
                         [alertController dismissByTappingCancelButton];
                     });
 
-                    it(@"should tap the cancel button regardless of where it is", ^{
+                    it(@"should tap the last button", ^{
                         handlerWasExecuted should be_truthy;
                     });
                 });
 
-                context(@"with a cancel button with no action", ^{
+                itShouldBehaveLike(@"default cancel behavior");
+            });
+
+            describe(@"UIAlertControllerStyleActionSheet", ^{
+                beforeEach(^{
+                    alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                          message:@"Message"
+                                                                   preferredStyle:UIAlertControllerStyleActionSheet];
+                });
+
+                context(@"when a action sheet does not have a cancel button", ^{
+                    beforeEach(^{
+                        addDefaultAction(alertController, handler);
+                    });
+
+                    it(@"should blow up", ^{
+                        ^{ [alertController dismissByTappingCancelButton]; } should raise_exception;
+                    });
+                });
+
+                itShouldBehaveLike(@"default cancel behavior");
+            });
+        });
+
+        describe(@"-dismissByTappingButtonWithTitle:", ^{
+            describe(@"UIAlertControllerStyleAlert", ^{
+                beforeEach(^{
+                    alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                          message:@"Message"
+                                                                   preferredStyle:UIAlertControllerStyleAlert];
+                });
+
+                context(@"when there is a button with a title", ^{
                     beforeEach(^{
                         addCancelAction(alertController, nil);
+                        addDefaultAction(alertController, handler);
+                        [alertController dismissByTappingButtonWithTitle:@"Default"];
                     });
 
-                    it(@"should not raise exception", ^{
-                        ^{ [alertController dismissByTappingCancelButton]; } should_not raise_exception;
+                    it(@"should tap the button", ^{
+                        handlerWasExecuted should be_truthy;
+                    });
+                });
+
+                context(@"when there is not a button with a title", ^{
+                    beforeEach(^{
+                        addDefaultAction(alertController, nil);
+                        addDefaultAction(alertController, handler);
+                    });
+
+                    it(@"should raise an exception stating a button with that title does not exist", ^{
+                        ^{ [alertController dismissByTappingButtonWithTitle:@"Non-existant"]; } should raise_exception;
+                    });
+                });
+
+                context(@"when the button does not have an action", ^{
+                    beforeEach(^{
+                        addDefaultAction(alertController, nil);
+                    });
+
+                    it(@"should not blow up", ^{
+                        ^{ [alertController dismissByTappingButtonWithTitle:@"Default"]; } should_not raise_exception;
                     });
                 });
             });
         });
 
-        describe(@"UIAlertControllerStyleAlert", ^{
-            beforeEach(^{
-                alertController = [UIAlertController alertControllerWithTitle:@"Title"
-                                                                      message:@"Message"
-                                                               preferredStyle:UIAlertControllerStyleAlert];
-                addDefaultAction(alertController, nil);
-            });
-
-            context(@"without containing a UIAlertActionStyleCancel button", ^{
-                beforeEach(^{
-                    addDefaultAction(alertController, handler);
-                    [alertController dismissByTappingCancelButton];
-                });
-
-                it(@"should tap the last button", ^{
-                    handlerWasExecuted should be_truthy;
-                });
-            });
-
-            itShouldBehaveLike(@"default cancel behavior");
-        });
-
-        describe(@"UIAlertControllerStyleActionSheet", ^{
-            beforeEach(^{
-                alertController = [UIAlertController alertControllerWithTitle:@"Title"
-                                                                      message:@"Message"
-                                                               preferredStyle:UIAlertControllerStyleActionSheet];
-            });
-
-            context(@"when a action sheet does not have a cancel button", ^{
-                beforeEach(^{
-                    addDefaultAction(alertController, handler);
-                });
-
-                it(@"should blow up", ^{
-                    ^{ [alertController dismissByTappingCancelButton]; } should raise_exception;
-                });
-            });
-
-            itShouldBehaveLike(@"default cancel behavior");
-        });
     });
-
-    describe(@"-dismissByTappingButtonWithTitle:", ^{
-        describe(@"UIAlertControllerStyleAlert", ^{
-            beforeEach(^{
-                alertController = [UIAlertController alertControllerWithTitle:@"Title"
-                                                                      message:@"Message"
-                                                               preferredStyle:UIAlertControllerStyleAlert];
-            });
-
-            context(@"when there is a button with a title", ^{
-                beforeEach(^{
-                    addCancelAction(alertController, nil);
-                    addDefaultAction(alertController, handler);
-                    [alertController dismissByTappingButtonWithTitle:@"Default"];
-                });
-
-                it(@"should tap the button", ^{
-                    handlerWasExecuted should be_truthy;
-                });
-            });
-
-            context(@"when there is not a button with a title", ^{
-                beforeEach(^{
-                    addDefaultAction(alertController, nil);
-                    addDefaultAction(alertController, handler);
-                });
-
-                it(@"should raise an exception stating a button with that title does not exist", ^{
-                    ^{ [alertController dismissByTappingButtonWithTitle:@"Non-existant"]; } should raise_exception;
-                });
-            });
-
-            context(@"when the button does not have an action", ^{
-                beforeEach(^{
-                    addDefaultAction(alertController, nil);
-                });
-
-                it(@"should not blow up", ^{
-                    ^{ [alertController dismissByTappingButtonWithTitle:@"Default"]; } should_not raise_exception;
-                });
-            });
-        });
-    });
-});
+}
+#endif
 
 SPEC_END

--- a/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
@@ -1,0 +1,106 @@
+#import "CDRSpecHelper.h"
+#import "UIAlertController+Spec.h"
+#import "UIAlertView+Spec.h"
+#import "UIAlertAction+Spec.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(UIAlertControllerSpec)
+
+describe(@"UIAlertController (spec extensions)", ^{
+    __block UIAlertController *alertController;
+    __block BOOL handlerWasExecuted;
+    __block PCKAlertActionHandler handler;
+
+    void (^addCancelAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
+        [controller addAction:[UIAlertAction actionWithTitle:@"Cancel"
+                                                       style:UIAlertActionStyleCancel
+                                                     handler:handler]];
+    };
+
+    void (^addDefaultAction)(UIAlertController *, PCKAlertActionHandler) = ^(UIAlertController *controller, PCKAlertActionHandler handler){
+        [controller addAction:[UIAlertAction actionWithTitle:@"Default"
+                                                       style:UIAlertActionStyleDefault
+                                                     handler:handler]];
+    };
+
+    beforeEach(^{
+        handlerWasExecuted = NO;
+        handler = ^(UIAlertAction *) { handlerWasExecuted = YES; };
+    });
+
+    describe(@"-dismissByTappingCancelButton", ^{
+        sharedExamplesFor(@"default cancel behavior", ^(NSDictionary *sharedContext) {
+            describe(@"tapping the cancel button", ^{
+                context(@"containing a UIAlertActionStyleCancel button", ^{
+                    beforeEach(^{
+                        addCancelAction(alertController, handler);
+                        addDefaultAction(alertController, nil);
+
+                        [alertController dismissByTappingCancelButton];
+                    });
+
+                    it(@"should tap the cancel button regardless of where it is", ^{
+                        handlerWasExecuted should be_truthy;
+                    });
+                });
+
+                context(@"with a cancel button with no action", ^{
+                    beforeEach(^{
+                        addCancelAction(alertController, nil);
+                    });
+
+                    it(@"should not raise exception", ^{
+                        ^{ [alertController dismissByTappingCancelButton]; } should_not raise_exception;
+                    });
+                });
+            });
+        });
+
+        describe(@"UIAlertControllerStyleAlert", ^{
+            beforeEach(^{
+                alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                      message:@"Message"
+                                                               preferredStyle:UIAlertControllerStyleAlert];
+                addDefaultAction(alertController, nil);
+            });
+
+            context(@"without containing a UIAlertActionStyleCancel button", ^{
+                beforeEach(^{
+                    addDefaultAction(alertController, handler);
+                    [alertController dismissByTappingCancelButton];
+                });
+
+                it(@"should tap the last button", ^{
+                    handlerWasExecuted should be_truthy;
+                });
+            });
+
+            itShouldBehaveLike(@"default cancel behavior");
+        });
+
+        describe(@"UIAlertControllerStyleActionSheet", ^{
+            beforeEach(^{
+                alertController = [UIAlertController alertControllerWithTitle:@"Title"
+                                                                      message:@"Message"
+                                                               preferredStyle:UIAlertControllerStyleActionSheet];
+            });
+
+            context(@"when a action sheet does not have a cancel button", ^{
+                beforeEach(^{
+                    addDefaultAction(alertController, handler);
+                    [alertController dismissByTappingCancelButton];
+                });
+
+                it(@"should not tap the last button", ^{
+                    handlerWasExecuted should be_falsy;
+                });
+            });
+
+            itShouldBehaveLike(@"default cancel behavior");
+        });
+    });
+});
+
+SPEC_END

--- a/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
@@ -8,7 +8,7 @@ using namespace Cedar::Doubles;
 
 SPEC_BEGIN(UIAlertControllerSpec)
 
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_8_0
 if (NSClassFromString(@"UIAlertController")) {
     describe(@"UIAlertController (spec extensions)", ^{
         __block UIAlertController *alertController;

--- a/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
@@ -90,11 +90,10 @@ describe(@"UIAlertController (spec extensions)", ^{
             context(@"when a action sheet does not have a cancel button", ^{
                 beforeEach(^{
                     addDefaultAction(alertController, handler);
-                    [alertController dismissByTappingCancelButton];
                 });
 
-                it(@"should not tap the last button", ^{
-                    handlerWasExecuted should be_falsy;
+                it(@"should blow up", ^{
+                    ^{ [alertController dismissByTappingCancelButton]; } should raise_exception;
                 });
             });
 

--- a/UIKit/Spec/Stubs/UIAlertViewSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertViewSpec+Spec.mm
@@ -32,7 +32,7 @@ describe(@"UIAlertView (spec extensions)", ^{
                                       otherButtonTitles:@"OK", nil] autorelease];
     });
 
-    describe(@"Getting the current alert view with currentAlertView", ^{
+    describe(@"getting the current alert view with currentAlertView", ^{
         describe(@"when the alert view is not shown", ^{
             beforeEach(^{
                 expect(alertView).to_not(be_visible());

--- a/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+typedef void (^PCKAlertActionHandler)(UIAlertAction *action);
+
+@interface UIAlertAction (Spec)
+
+- (PCKAlertActionHandler)handler;
+
+@end

--- a/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_8_0
 typedef void (^PCKAlertActionHandler)(UIAlertAction *action);
 
 @interface UIAlertAction (Spec)

--- a/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+#ifdef __IPHONE_8_0
 typedef void (^PCKAlertActionHandler)(UIAlertAction *action);
 
 @interface UIAlertAction (Spec)
@@ -7,3 +8,4 @@ typedef void (^PCKAlertActionHandler)(UIAlertAction *action);
 - (PCKAlertActionHandler)handler;
 
 @end
+#endif

--- a/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.m
@@ -2,6 +2,8 @@
 #import "PCKMethodRedirector.h"
 #import <objc/objc-runtime.h>
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_8_0
+
 static char * kHandlerKey;
 
 @interface UIAlertAction (SpecPrivate)
@@ -28,3 +30,4 @@ static char * kHandlerKey;
 }
 
 @end
+#endif

--- a/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.m
@@ -1,0 +1,30 @@
+#import "UIAlertAction+Spec.h"
+#import "PCKMethodRedirector.h"
+#import <objc/objc-runtime.h>
+
+static char * kHandlerKey;
+
+@interface UIAlertAction (SpecPrivate)
++ (instancetype)original_actionWithTitle:(NSString *)title style:(UIAlertActionStyle)style handler:(void (^)(UIAlertAction *))handler;
+@end
+
+@implementation UIAlertAction (Spec)
+
++ (void)load {
+    [PCKMethodRedirector redirectSelector:@selector(actionWithTitle:style:handler:)
+                                 forClass:objc_getMetaClass(class_getName([self class]))
+                                       to:@selector(_actionWithTitle:style:handler:)
+                            andRenameItTo:@selector(original_actionWithTitle:style:handler:)];
+}
+
++ (instancetype)_actionWithTitle:(NSString *)title style:(UIAlertActionStyle)style handler:(void (^)(UIAlertAction *))handler {
+    UIAlertAction *action = [self original_actionWithTitle:title style:style handler:handler];
+    objc_setAssociatedObject(action, &kHandlerKey, handler, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    return action;
+}
+
+- (PCKAlertActionHandler)handler {
+    return objc_getAssociatedObject(self, &kHandlerKey);
+}
+
+@end

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface UIAlertController (Spec)
+
+- (void)dismissByTappingCancelButton;
+
+@end

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_8_0
 @interface UIAlertController (Spec)
 
 - (void)dismissByTappingCancelButton;

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
@@ -1,8 +1,10 @@
 #import <UIKit/UIKit.h>
 
+#ifdef __IPHONE_8_0
 @interface UIAlertController (Spec)
 
 - (void)dismissByTappingCancelButton;
 - (void)dismissByTappingButtonWithTitle:(NSString *)title;
 
 @end
+#endif

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
@@ -3,5 +3,6 @@
 @interface UIAlertController (Spec)
 
 - (void)dismissByTappingCancelButton;
+- (void)dismissByTappingButtonWithTitle:(NSString *)title;
 
 @end

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
@@ -1,0 +1,28 @@
+#import "UIAlertController+Spec.h"
+#import "UIAlertAction+Spec.h"
+
+@implementation UIAlertController (Spec)
+
+- (void)dismissByTappingCancelButton {
+    UIAlertAction *cancelAction = [self cancelAction];
+    if (cancelAction.handler) {
+        cancelAction.handler(cancelAction);
+    }
+}
+
+#pragma mark - Private
+
+- (UIAlertAction *)cancelAction {
+    NSPredicate *cancelPredicate = [NSPredicate predicateWithBlock:^BOOL(UIAlertAction *action, NSDictionary *bindings) {
+        return action.style == UIAlertActionStyleCancel;
+    }];
+
+    UIAlertAction *cancelAction = [[self.actions filteredArrayUsingPredicate:cancelPredicate] lastObject];
+    if (self.preferredStyle == UIAlertControllerStyleActionSheet) {
+        return cancelAction;
+    } else {
+        return cancelAction ? cancelAction : self.actions.lastObject;
+    }
+}
+
+@end

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
@@ -10,6 +10,13 @@
     }
 }
 
+- (void)dismissByTappingButtonWithTitle:(NSString *)title {
+    UIAlertAction *action = [self actionWithButtonTitle:title];
+    if (action.handler) {
+        action.handler(action);
+    }
+}
+
 #pragma mark - Private
 
 - (UIAlertAction *)cancelAction {
@@ -23,6 +30,13 @@
     } else {
         return cancelAction ? cancelAction : self.actions.lastObject;
     }
+}
+
+- (UIAlertAction *)actionWithButtonTitle:(NSString *)title {
+    NSArray *buttonTitles = [self.actions valueForKey:@"title"];
+    NSUInteger buttonIndex = [buttonTitles indexOfObject:title];
+    NSAssert((buttonIndex != NSNotFound), @"UIAlertController does not have a button titled '%@' -- current button titles are %@", title, buttonTitles);
+    return self.actions[buttonIndex];
 }
 
 @end

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
@@ -1,6 +1,8 @@
 #import "UIAlertController+Spec.h"
 #import "UIAlertAction+Spec.h"
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_8_0
+
 @implementation UIAlertController (Spec)
 
 - (void)dismissByTappingCancelButton {
@@ -41,3 +43,5 @@
 }
 
 @end
+
+#endif

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
@@ -26,6 +26,7 @@
 
     UIAlertAction *cancelAction = [[self.actions filteredArrayUsingPredicate:cancelPredicate] lastObject];
     if (self.preferredStyle == UIAlertControllerStyleActionSheet) {
+        NSAssert(cancelAction, @"UIAlertController does not have a cancel button");
         return cancelAction;
     } else {
         return cancelAction ? cancelAction : self.actions.lastObject;

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedGestureRecognizers.h
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedGestureRecognizers.h
@@ -3,7 +3,8 @@
 @interface UIView (StubbedGestureRecognizers)
 
 - (void)tap;
-- (void)swipe;
+/*! @abstract Use swipeInDirection: instead. */
+- (void)swipe DEPRECATED_ATTRIBUTE;
 - (void)swipeInDirection:(UISwipeGestureRecognizerDirection)swipeDirection;
 - (void)pinch;
 

--- a/UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h
+++ b/UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h
@@ -5,3 +5,4 @@
 #import "UIImagePickerController+Spec.h"
 #import "UIGestureRecognizer+Spec.h"
 #import "UIAlertAction+Spec.h"
+#import "UIAlertController+Spec.h"

--- a/UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h
+++ b/UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h
@@ -4,3 +4,4 @@
 #import "UITabBarController+Spec.h"
 #import "UIImagePickerController+Spec.h"
 #import "UIGestureRecognizer+Spec.h"
+#import "UIAlertAction+Spec.h"

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		34BDAC7F19A433510085B45A /* UICollectionReusableView+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 34BDAC7519A42C5F0085B45A /* UICollectionReusableView+Spec.h */; };
 		8487257E19013F6400288770 /* UIActivityViewController+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8487257219013F5F00288770 /* UIActivityViewController+Spec.m */; };
 		84C62A78190141DD00DF2982 /* UIActivityViewControllerSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		AE062BD01A43240500AF8D33 /* UIAlertActionSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE062BCE1A4323CF00AF8D33 /* UIAlertActionSpec+Spec.mm */; };
+		AE062BD11A43241B00AF8D33 /* UIAlertAction+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE062BC01A4323A800AF8D33 /* UIAlertAction+Spec.m */; };
 		AE118AA418D6B57000C90D6B /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE118AA318D6B57000C90D6B /* SenTestingKit.framework */; };
 		AE118AA718D6B57000C90D6B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AEBCCBE7168B97DD0056EE83 /* Foundation.framework */; };
 		AE118AC218D6B63900C90D6B /* BundleSpecLoader.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE118AC118D6B63900C90D6B /* BundleSpecLoader.mm */; };
@@ -373,6 +375,9 @@
 		8487257119013F5F00288770 /* UIActivityViewController+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIActivityViewController+Spec.h"; sourceTree = "<group>"; };
 		8487257219013F5F00288770 /* UIActivityViewController+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIActivityViewController+Spec.m"; sourceTree = "<group>"; };
 		8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIActivityViewControllerSpec+Spec.mm"; sourceTree = "<group>"; };
+		AE062BBF1A4323A800AF8D33 /* UIAlertAction+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAlertAction+Spec.h"; sourceTree = "<group>"; };
+		AE062BC01A4323A800AF8D33 /* UIAlertAction+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIAlertAction+Spec.m"; sourceTree = "<group>"; };
+		AE062BCE1A4323CF00AF8D33 /* UIAlertActionSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIAlertActionSpec+Spec.mm"; sourceTree = "<group>"; };
 		AE118AA218D6B57000C90D6B /* UIKit-StaticLibSpecBundle.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UIKit-StaticLibSpecBundle.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE118AA318D6B57000C90D6B /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		AE118AC118D6B63900C90D6B /* BundleSpecLoader.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BundleSpecLoader.mm; sourceTree = "<group>"; };
@@ -789,6 +794,8 @@
 				AEC40CAF174C22BD00474D2D /* UIActionSheet+Spec.m */,
 				8487257119013F5F00288770 /* UIActivityViewController+Spec.h */,
 				8487257219013F5F00288770 /* UIActivityViewController+Spec.m */,
+				AE062BBF1A4323A800AF8D33 /* UIAlertAction+Spec.h */,
+				AE062BC01A4323A800AF8D33 /* UIAlertAction+Spec.m */,
 				AEC40CB0174C22BD00474D2D /* UIAlertView+Spec.h */,
 				AEC40CB1174C22BD00474D2D /* UIAlertView+Spec.m */,
 				DE99C78703C6C6CA8C0465B3 /* UIGestureRecognizer+Spec.h */,
@@ -814,6 +821,7 @@
 			children = (
 				AEF67CE018CA436600C221D1 /* UIActionSheetSpec+Spec.mm */,
 				8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */,
+				AE062BCE1A4323CF00AF8D33 /* UIAlertActionSpec+Spec.mm */,
 				AEC40CBE174C24CF00474D2D /* UIAlertViewSpec+Spec.mm */,
 				AEEECC32181F33F5006B52CD /* UIImagePickerControllerSpec+Spec.mm */,
 				AEEDC56719FAC2E2004AFFE9 /* UINavigationControllerSpec+Spec.mm */,
@@ -1221,6 +1229,8 @@
 				FA91AA9E1867260400925A6B /* NSString+PivotalCoreKit_UIKitSpec.mm in Sources */,
 				AE7B279617CFD67600904F64 /* UIViewControllerSpec+Spec.mm in Sources */,
 				AE95306A1832EE9300C802E9 /* UIViewSpec+Spec.mm in Sources */,
+				AE062BD01A43240500AF8D33 /* UIAlertActionSpec+Spec.mm in Sources */,
+				AE062BD11A43241B00AF8D33 /* UIAlertAction+Spec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -785,8 +785,6 @@
 		AEC40C95174C21AC00474D2D /* Stubs */ = {
 			isa = PBXGroup;
 			children = (
-				AECB46AA1A3FBA9E00398720 /* UIView+StubbedGestureRecognizers.h */,
-				AECB46AB1A3FBA9E00398720 /* UIView+StubbedGestureRecognizers.m */,
 				AEC40CAE174C22BD00474D2D /* UIActionSheet+Spec.h */,
 				AEC40CAF174C22BD00474D2D /* UIActionSheet+Spec.m */,
 				8487257119013F5F00288770 /* UIActivityViewController+Spec.h */,
@@ -802,6 +800,8 @@
 				AEB6662B18C6681A00B09C00 /* UIPopoverController+Spec.m */,
 				AEE0B69518A3572C0007A9D0 /* UIView+StubbedAnimation.h */,
 				AE89900218071F3A00DDB948 /* UIView+StubbedAnimation.m */,
+				AECB46AA1A3FBA9E00398720 /* UIView+StubbedGestureRecognizers.h */,
+				AECB46AB1A3FBA9E00398720 /* UIView+StubbedGestureRecognizers.m */,
 				AEC40CB2174C22BD00474D2D /* UIViewController+Spec.m */,
 				AEC40CB3174C22BD00474D2D /* UIWebView+Spec.h */,
 				AEC40CB4174C22BD00474D2D /* UIWebView+Spec.m */,
@@ -813,6 +813,7 @@
 			isa = PBXGroup;
 			children = (
 				AEF67CE018CA436600C221D1 /* UIActionSheetSpec+Spec.mm */,
+				8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */,
 				AEC40CBE174C24CF00474D2D /* UIAlertViewSpec+Spec.mm */,
 				AEEECC32181F33F5006B52CD /* UIImagePickerControllerSpec+Spec.mm */,
 				AEEDC56719FAC2E2004AFFE9 /* UINavigationControllerSpec+Spec.mm */,
@@ -820,7 +821,6 @@
 				AE7B279517CFD67600904F64 /* UIViewControllerSpec+Spec.mm */,
 				AE898FF718071E2B00DDB948 /* UIViewSpec+StubbedAnimations.mm */,
 				AEC40CBF174C24CF00474D2D /* UIWebViewSpec+Spec.mm */,
-				8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */,
 			);
 			path = Stubs;
 			sourceTree = "<group>";

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -73,6 +73,9 @@
 		AE3B43901A30D95200265154 /* PCKMethodRedirector.m in Sources */ = {isa = PBXBuildFile; fileRef = AEF5D45C1A030D2E00C4DC3D /* PCKMethodRedirector.m */; };
 		AE53E2EC18075A810037C32E /* UIWindow+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE53E2EB18075A810037C32E /* UIWindow+Spec.m */; };
 		AE53E2F618075B080037C32E /* UIWindowSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE53E2F518075B080037C32E /* UIWindowSpec+Spec.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		AE61C1211A40B5BE00C97245 /* UIAlertControllerSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE61C11F1A40B59000C97245 /* UIAlertControllerSpec+Spec.mm */; };
+		AE61C13F1A40B98900C97245 /* UIAlertController+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE61C1301A40B95E00C97245 /* UIAlertController+Spec.h */; };
+		AE61C1401A40B98E00C97245 /* UIAlertController+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE61C1311A40B95E00C97245 /* UIAlertController+Spec.m */; };
 		AE7B279617CFD67600904F64 /* UIViewControllerSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE7B279517CFD67600904F64 /* UIViewControllerSpec+Spec.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		AE7CE69319FACA8B007B008F /* NavigationStackExample.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE7CE69219FACA84007B008F /* NavigationStackExample.storyboard */; };
 		AE86BD42179C7C910057DEAE /* UITabBarController+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE86BD40179C7C910057DEAE /* UITabBarController+Spec.h */; };
@@ -326,6 +329,7 @@
 				AEC40CCB174C292600474D2D /* UIWebView+Spec.h in Copy headers to framework */,
 				AECB46BA1A3FBB6C00398720 /* UIGestureRecognizer+Spec.h in Copy headers to framework */,
 				AEF5D45D1A030D2E00C4DC3D /* PCKMethodRedirector.h in Copy headers to framework */,
+				AE61C13F1A40B98900C97245 /* UIAlertController+Spec.h in Copy headers to framework */,
 				AE244D4319077EEB00ED96E9 /* UIActivityViewController+Spec.h in Copy headers to framework */,
 				AEC40CCC174C292600474D2D /* UIKit+PivotalSpecHelperStubs.h in Copy headers to framework */,
 				AEB6662C18C6681A00B09C00 /* UIPopoverController+Spec.h in Copy headers to framework */,
@@ -393,6 +397,9 @@
 		AE53E2EA18075A810037C32E /* UIWindow+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIWindow+Spec.h"; sourceTree = "<group>"; };
 		AE53E2EB18075A810037C32E /* UIWindow+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIWindow+Spec.m"; sourceTree = "<group>"; };
 		AE53E2F518075B080037C32E /* UIWindowSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIWindowSpec+Spec.mm"; sourceTree = "<group>"; };
+		AE61C11F1A40B59000C97245 /* UIAlertControllerSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIAlertControllerSpec+Spec.mm"; sourceTree = "<group>"; };
+		AE61C1301A40B95E00C97245 /* UIAlertController+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAlertController+Spec.h"; sourceTree = "<group>"; };
+		AE61C1311A40B95E00C97245 /* UIAlertController+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIAlertController+Spec.m"; sourceTree = "<group>"; };
 		AE7B279517CFD67600904F64 /* UIViewControllerSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIViewControllerSpec+Spec.mm"; sourceTree = "<group>"; };
 		AE7CE69219FACA84007B008F /* NavigationStackExample.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = NavigationStackExample.storyboard; sourceTree = "<group>"; };
 		AE86BD40179C7C910057DEAE /* UITabBarController+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBarController+Spec.h"; sourceTree = "<group>"; };
@@ -796,6 +803,8 @@
 				8487257219013F5F00288770 /* UIActivityViewController+Spec.m */,
 				AE062BBF1A4323A800AF8D33 /* UIAlertAction+Spec.h */,
 				AE062BC01A4323A800AF8D33 /* UIAlertAction+Spec.m */,
+				AE61C1301A40B95E00C97245 /* UIAlertController+Spec.h */,
+				AE61C1311A40B95E00C97245 /* UIAlertController+Spec.m */,
 				AEC40CB0174C22BD00474D2D /* UIAlertView+Spec.h */,
 				AEC40CB1174C22BD00474D2D /* UIAlertView+Spec.m */,
 				DE99C78703C6C6CA8C0465B3 /* UIGestureRecognizer+Spec.h */,
@@ -822,6 +831,7 @@
 				AEF67CE018CA436600C221D1 /* UIActionSheetSpec+Spec.mm */,
 				8487257F1901402000288770 /* UIActivityViewControllerSpec+Spec.mm */,
 				AE062BCE1A4323CF00AF8D33 /* UIAlertActionSpec+Spec.mm */,
+				AE61C11F1A40B59000C97245 /* UIAlertControllerSpec+Spec.mm */,
 				AEC40CBE174C24CF00474D2D /* UIAlertViewSpec+Spec.mm */,
 				AEEECC32181F33F5006B52CD /* UIImagePickerControllerSpec+Spec.mm */,
 				AEEDC56719FAC2E2004AFFE9 /* UINavigationControllerSpec+Spec.mm */,
@@ -1214,6 +1224,7 @@
 				AE3847AD168BA0E300C99B55 /* AWebViewController.m in Sources */,
 				AEC6D7FE16963F3500E10C7B /* UIControlSpec+Spec.mm in Sources */,
 				AE898FF818071E2B00DDB948 /* UIViewSpec+StubbedAnimations.mm in Sources */,
+				AE61C1211A40B5BE00C97245 /* UIAlertControllerSpec+Spec.mm in Sources */,
 				22601B5916BA209F00A807CB /* UISliderSpec+Spec.mm in Sources */,
 				B8C62E6F16BC04230009CDAD /* UIBarButtonItemSpec+Spec.mm in Sources */,
 				AEDABBBB18EA214A004E6626 /* ChildViewController.m in Sources */,
@@ -1267,6 +1278,7 @@
 				AEC40CB8174C22BD00474D2D /* UIWebView+Spec.m in Sources */,
 				8487257E19013F6400288770 /* UIActivityViewController+Spec.m in Sources */,
 				AE3B43901A30D95200265154 /* PCKMethodRedirector.m in Sources */,
+				AE61C1401A40B98E00C97245 /* UIAlertController+Spec.m in Sources */,
 				AE86BD43179C7C910057DEAE /* UITabBarController+Spec.m in Sources */,
 				DE99CA8267EEACF8EE9A941F /* UIGestureRecognizer+Spec.m in Sources */,
 			);

--- a/WatchKit/Specs/Fixtures/CustomCategoryNotificationController.h
+++ b/WatchKit/Specs/Fixtures/CustomCategoryNotificationController.h
@@ -1,0 +1,8 @@
+#import <WatchKit/WatchKit.h>
+#import <Foundation/Foundation.h>
+
+@interface CustomCategoryNotificationController : WKUserNotificationInterfaceController
+
+@property (weak, nonatomic, readonly) WKInterfaceLabel *alertLabel;
+
+@end

--- a/WatchKit/Specs/Fixtures/CustomCategoryNotificationController.m
+++ b/WatchKit/Specs/Fixtures/CustomCategoryNotificationController.m
@@ -1,0 +1,12 @@
+#import "CustomCategoryNotificationController.h"
+
+
+@interface CustomCategoryNotificationController()
+
+@property (weak, nonatomic) IBOutlet WKInterfaceLabel *alertLabel;
+
+@end
+
+
+@implementation CustomCategoryNotificationController
+@end

--- a/WatchKit/Specs/Fixtures/Interface.storyboard
+++ b/WatchKit/Specs/Fixtures/Interface.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="6724" systemVersion="14B25" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="6724" systemVersion="13F34" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6711"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="3735"/>
@@ -224,6 +224,23 @@
             </objects>
             <point key="canvasLocation" x="-141" y="975"/>
         </scene>
+        <!--Static Custom Category Notificaiton Controller-->
+        <scene sceneID="ipe-TL-10Q">
+            <objects>
+                <notificationController id="4dq-ES-tTS" userLabel="Static Custom Category Notificaiton Controller">
+                    <items>
+                        <label alignment="left" text="Alert Label" id="gth-Xy-UKJ"/>
+                    </items>
+                    <notificationCategory key="notificationCategory" identifier="com.pivotal.core.watch" offsetNotificationContent="NO" id="xZt-uM-zwi"/>
+                    <color key="backgroundColor" red="0.0" green="0.39051094890510951" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <connections>
+                        <outlet property="notificationAlertLabel" destination="gth-Xy-UKJ" id="TeN-wW-GCP"/>
+                        <segue destination="1AB-mn-kEw" kind="relationship" relationship="dynamicNotificationInterface" id="WIg-Dl-M4J"/>
+                    </connections>
+                </notificationController>
+            </objects>
+            <point key="canvasLocation" x="-141" y="1199"/>
+        </scene>
         <!--Notification Controller-->
         <scene sceneID="KIl-fV-djm">
             <objects>
@@ -237,6 +254,20 @@
                 </controller>
             </objects>
             <point key="canvasLocation" x="103" y="975"/>
+        </scene>
+        <!--Dynamic Custom Notification Category Controller-->
+        <scene sceneID="czZ-Yx-jMA">
+            <objects>
+                <controller id="1AB-mn-kEw" userLabel="Dynamic Custom Notification Category Controller" customClass="CustomCategoryNotificationController">
+                    <items>
+                        <label width="134" height="54" alignment="center" verticalAlignment="center" text="Category Alert" textAlignment="center" id="CbI-jE-Vdc"/>
+                    </items>
+                    <connections>
+                        <outlet property="alertLabel" destination="CbI-jE-Vdc" id="Tvf-nz-hvI"/>
+                    </connections>
+                </controller>
+            </objects>
+            <point key="canvasLocation" x="104" y="1197"/>
         </scene>
     </scenes>
 </document>

--- a/WatchKit/Specs/WatchKit/WKInterfaceImageSpec.mm
+++ b/WatchKit/Specs/WatchKit/WKInterfaceImageSpec.mm
@@ -55,6 +55,12 @@ describe(@"WKInterfaceImage", ^{
 
             subject should have_received(@selector(stopAnimating));
         });
+
+        it(@"should record the invocation for setTintColor:", ^{
+            [subject setTintColor:[UIColor clearColor]];
+
+            subject should have_received(@selector(setTintColor:)).with([UIColor clearColor]);
+        });
     });
 });
 

--- a/WatchKit/WatchKit.xcodeproj/project.pbxproj
+++ b/WatchKit/WatchKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AE03A0391A391C5900AD4964 /* corgi.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = AE03A0381A391C5900AD4964 /* corgi.jpeg */; };
+		AE0FDC801A6ECB71006C781D /* CustomCategoryNotificationController.m in Sources */ = {isa = PBXBuildFile; fileRef = AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */; };
 		AE25D5FE1A38F6C9008A1920 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D5FD1A38F6C9008A1920 /* XCTest.framework */; };
 		AE25D6001A38F6C9008A1920 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D5FF1A38F6C9008A1920 /* CoreGraphics.framework */; };
 		AE25D6021A38F6C9008A1920 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D6011A38F6C9008A1920 /* UIKit.framework */; };
@@ -194,6 +195,8 @@
 
 /* Begin PBXFileReference section */
 		AE03A0381A391C5900AD4964 /* corgi.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = corgi.jpeg; sourceTree = "<group>"; };
+		AE0FDC7E1A6ECB71006C781D /* CustomCategoryNotificationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomCategoryNotificationController.h; sourceTree = "<group>"; };
+		AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomCategoryNotificationController.m; sourceTree = "<group>"; };
 		AE25D5FB1A38F6C9008A1920 /* Specs.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Specs.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE25D5FD1A38F6C9008A1920 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		AE25D5FF1A38F6C9008A1920 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = /System/Library/Frameworks/CoreGraphics.framework; sourceTree = "<absolute>"; };
@@ -424,6 +427,10 @@
 				AED5709B1A3A4786004ABADA /* CorgisController.m */,
 				AEB03ED01A3F9FFF002404BC /* CorgiTableController.h */,
 				AEB03ED11A3F9FFF002404BC /* CorgiTableController.m */,
+				AE0FDC7E1A6ECB71006C781D /* CustomCategoryNotificationController.h */,
+				AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */,
+				AEAA43D11A5F4CBE0034358B /* GlanceController.h */,
+				AEAA43D21A5F4CBE0034358B /* GlanceController.m */,
 				AE85C05F1A3FC03B009A0E4D /* GroupController.h */,
 				AE85C0601A3FC03B009A0E4D /* GroupController.m */,
 				AE25D65D1A38FFA9008A1920 /* Interface.storyboard */,
@@ -437,8 +444,6 @@
 				AE85C06F1A40B974009A0E4D /* plus@2x.png */,
 				AE85C0621A40A4F4009A0E4D /* SliderController.h */,
 				AE85C0631A40A4F4009A0E4D /* SliderController.m */,
-				AEAA43D11A5F4CBE0034358B /* GlanceController.h */,
-				AEAA43D21A5F4CBE0034358B /* GlanceController.m */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -765,6 +770,7 @@
 				B83C32581A4CE18C0021F1A4 /* WKInterfaceTimerSpec.mm in Sources */,
 				AE85C0641A40A4F4009A0E4D /* SliderController.m in Sources */,
 				AEAA43D31A5F4CBE0034358B /* GlanceController.m in Sources */,
+				AE0FDC801A6ECB71006C781D /* CustomCategoryNotificationController.m in Sources */,
 				B83C32541A4CE18C0021F1A4 /* WKInterfaceObjectSpec.mm in Sources */,
 				AEB03EDE1A3FB366002404BC /* MapController.m in Sources */,
 				B83C324E1A4CE18C0021F1A4 /* WKInterfaceControllerSpec.mm in Sources */,

--- a/WatchKit/WatchKit/PCKInterfaceControllerLoader.h
+++ b/WatchKit/WatchKit/PCKInterfaceControllerLoader.h
@@ -8,7 +8,8 @@
                                      bundle:(NSBundle *)bundle;
 
 - (id)dynamicNotificationInterfaceControllerWithStoryboardName:(NSString *)storyboardName
-                                                        bundle:(NSBundle *)bundle;
+                                                        bundle:(NSBundle *)bundle
+                                          notificationCategory:(NSString *)notificationCategory;
 
 - (id)glanceInterfaceControllerWithStoryboardName:(NSString *)storyboardName
                                        identifier:(NSString *)objectID

--- a/WatchKit/WatchKit/PCKInterfaceControllerLoader.m
+++ b/WatchKit/WatchKit/PCKInterfaceControllerLoader.m
@@ -33,6 +33,7 @@
 
 - (id)dynamicNotificationInterfaceControllerWithStoryboardName:(NSString *)storyboardName
                                                         bundle:(NSBundle *)bundle
+                                          notificationCategory:(NSString *)notificationCategory
 {
     NSString *processedStoryboardName = [storyboardName stringByAppendingString:@"-notification"];
     NSString *pathForPlist = [bundle pathForResource:processedStoryboardName ofType:@"plist"];
@@ -45,7 +46,8 @@
 
     NSDictionary *serializedNotificationControllerStoryboard = [NSDictionary dictionaryWithContentsOfFile:pathForPlist];
 
-    NSDictionary *controllerProperties = serializedNotificationControllerStoryboard[@"categories"][@"default"][@"dynamic"];
+    NSString *categoryKey = notificationCategory ? notificationCategory : @"default";
+    NSDictionary *controllerProperties = serializedNotificationControllerStoryboard[@"categories"][categoryKey][@"dynamic"];
     PCKDynamicWatchKitObjectProvider *provider = [[PCKDynamicWatchKitObjectProvider alloc] init];
 
     return [provider interfaceControllerWithProperties:controllerProperties];

--- a/WatchKit/WatchKit/WKInterfaceController.h
+++ b/WatchKit/WatchKit/WKInterfaceController.h
@@ -3,7 +3,7 @@
 typedef NS_ENUM(NSInteger, WKUserNotificationInterfaceType)  {
     WKUserNotificationInterfaceTypeDefault,
     WKUserNotificationInterfaceTypeCustom,
-} NS_ENUM_AVAILABLE_IOS(8_2);
+};
 
 @class WKInterfaceTable;
 
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSInteger, WKMenuItemIcon)  {
     WKMenuItemIconShuffle,      // swapped arrows
     WKMenuItemIconSpeaker,      // speaker icon
     WKMenuItemIconTrash,        // trash icon
-} NS_ENUM_AVAILABLE_IOS(8_2);
+};
 
 typedef enum WKTextInputMode : NSInteger  {
     WKTextInputModePlain,

--- a/WatchKit/WatchKit/WKInterfaceImage.h
+++ b/WatchKit/WatchKit/WKInterfaceImage.h
@@ -7,6 +7,8 @@
 - (void)setImageData:(NSData *)imageData;
 - (void)setImageNamed:(NSString *)imageName;
 
+- (void)setTintColor:(UIColor *)tintColor;
+
 - (void)startAnimating;
 
 - (void)startAnimatingWithImagesInRange:(NSRange)imageRange

--- a/WatchKit/WatchKit/WKInterfaceImage.m
+++ b/WatchKit/WatchKit/WKInterfaceImage.m
@@ -7,6 +7,8 @@
 - (void)setImageData:(NSData *)imageData NS_REQUIRES_SUPER;
 - (void)setImageNamed:(NSString *)imageName NS_REQUIRES_SUPER;
 
+- (void)setTintColor:(UIColor *)tintColor NS_REQUIRES_SUPER;
+
 - (void)startAnimating NS_REQUIRES_SUPER;
 - (void)startAnimatingWithImagesInRange:(NSRange)imageRange
                                duration:(NSTimeInterval)duration
@@ -56,6 +58,9 @@
     [super stopAnimating];
 }
 
-
+- (void)setTintColor:(UIColor *)tintColor
+{
+    [super setTintColor:tintColor];
+}
 
 @end


### PR DESCRIPTION
Added ability to instantiate WKUserNotificationInterfaceController subclasses configured for specific notification categories.  Wasn't sure if leaving PCKInterfaceControlelrLoader's existing interface in place and adding an overload was preferable to mutating the existing interface to now accept notificationCategory.