### PR TITLE
Add ability to instantiate WKUserNotificationInterfaceController subclas...

### DIFF
--- a/WatchKit/Specs/Fixtures/CustomCategoryNotificationController.h
+++ b/WatchKit/Specs/Fixtures/CustomCategoryNotificationController.h
@@ -1,0 +1,8 @@
+#import <WatchKit/WatchKit.h>
+#import <Foundation/Foundation.h>
+
+@interface CustomCategoryNotificationController : WKUserNotificationInterfaceController
+
+@property (weak, nonatomic, readonly) WKInterfaceLabel *alertLabel;
+
+@end

--- a/WatchKit/Specs/Fixtures/CustomCategoryNotificationController.m
+++ b/WatchKit/Specs/Fixtures/CustomCategoryNotificationController.m
@@ -1,0 +1,12 @@
+#import "CustomCategoryNotificationController.h"
+
+
+@interface CustomCategoryNotificationController()
+
+@property (weak, nonatomic) IBOutlet WKInterfaceLabel *alertLabel;
+
+@end
+
+
+@implementation CustomCategoryNotificationController
+@end

--- a/WatchKit/Specs/Fixtures/Interface.storyboard
+++ b/WatchKit/Specs/Fixtures/Interface.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="6724" systemVersion="14B25" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="6724" systemVersion="13F34" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6711"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="3735"/>
@@ -224,6 +224,23 @@
             </objects>
             <point key="canvasLocation" x="-141" y="975"/>
         </scene>
+        <!--Static Custom Category Notificaiton Controller-->
+        <scene sceneID="ipe-TL-10Q">
+            <objects>
+                <notificationController id="4dq-ES-tTS" userLabel="Static Custom Category Notificaiton Controller">
+                    <items>
+                        <label alignment="left" text="Alert Label" id="gth-Xy-UKJ"/>
+                    </items>
+                    <notificationCategory key="notificationCategory" identifier="com.pivotal.core.watch" offsetNotificationContent="NO" id="xZt-uM-zwi"/>
+                    <color key="backgroundColor" red="0.0" green="0.39051094890510951" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <connections>
+                        <outlet property="notificationAlertLabel" destination="gth-Xy-UKJ" id="TeN-wW-GCP"/>
+                        <segue destination="1AB-mn-kEw" kind="relationship" relationship="dynamicNotificationInterface" id="WIg-Dl-M4J"/>
+                    </connections>
+                </notificationController>
+            </objects>
+            <point key="canvasLocation" x="-141" y="1199"/>
+        </scene>
         <!--Notification Controller-->
         <scene sceneID="KIl-fV-djm">
             <objects>
@@ -237,6 +254,20 @@
                 </controller>
             </objects>
             <point key="canvasLocation" x="103" y="975"/>
+        </scene>
+        <!--Dynamic Custom Notification Category Controller-->
+        <scene sceneID="czZ-Yx-jMA">
+            <objects>
+                <controller id="1AB-mn-kEw" userLabel="Dynamic Custom Notification Category Controller" customClass="CustomCategoryNotificationController">
+                    <items>
+                        <label width="134" height="54" alignment="center" verticalAlignment="center" text="Category Alert" textAlignment="center" id="CbI-jE-Vdc"/>
+                    </items>
+                    <connections>
+                        <outlet property="alertLabel" destination="CbI-jE-Vdc" id="Tvf-nz-hvI"/>
+                    </connections>
+                </controller>
+            </objects>
+            <point key="canvasLocation" x="104" y="1197"/>
         </scene>
     </scenes>
 </document>

--- a/WatchKit/WatchKit.xcodeproj/project.pbxproj
+++ b/WatchKit/WatchKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AE03A0391A391C5900AD4964 /* corgi.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = AE03A0381A391C5900AD4964 /* corgi.jpeg */; };
+		AE0FDC801A6ECB71006C781D /* CustomCategoryNotificationController.m in Sources */ = {isa = PBXBuildFile; fileRef = AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */; };
 		AE25D5FE1A38F6C9008A1920 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D5FD1A38F6C9008A1920 /* XCTest.framework */; };
 		AE25D6001A38F6C9008A1920 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D5FF1A38F6C9008A1920 /* CoreGraphics.framework */; };
 		AE25D6021A38F6C9008A1920 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D6011A38F6C9008A1920 /* UIKit.framework */; };
@@ -194,6 +195,8 @@
 
 /* Begin PBXFileReference section */
 		AE03A0381A391C5900AD4964 /* corgi.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = corgi.jpeg; sourceTree = "<group>"; };
+		AE0FDC7E1A6ECB71006C781D /* CustomCategoryNotificationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomCategoryNotificationController.h; sourceTree = "<group>"; };
+		AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomCategoryNotificationController.m; sourceTree = "<group>"; };
 		AE25D5FB1A38F6C9008A1920 /* Specs.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Specs.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE25D5FD1A38F6C9008A1920 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		AE25D5FF1A38F6C9008A1920 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = /System/Library/Frameworks/CoreGraphics.framework; sourceTree = "<absolute>"; };
@@ -424,6 +427,10 @@
 				AED5709B1A3A4786004ABADA /* CorgisController.m */,
 				AEB03ED01A3F9FFF002404BC /* CorgiTableController.h */,
 				AEB03ED11A3F9FFF002404BC /* CorgiTableController.m */,
+				AE0FDC7E1A6ECB71006C781D /* CustomCategoryNotificationController.h */,
+				AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */,
+				AEAA43D11A5F4CBE0034358B /* GlanceController.h */,
+				AEAA43D21A5F4CBE0034358B /* GlanceController.m */,
 				AE85C05F1A3FC03B009A0E4D /* GroupController.h */,
 				AE85C0601A3FC03B009A0E4D /* GroupController.m */,
 				AE25D65D1A38FFA9008A1920 /* Interface.storyboard */,
@@ -437,8 +444,6 @@
 				AE85C06F1A40B974009A0E4D /* plus@2x.png */,
 				AE85C0621A40A4F4009A0E4D /* SliderController.h */,
 				AE85C0631A40A4F4009A0E4D /* SliderController.m */,
-				AEAA43D11A5F4CBE0034358B /* GlanceController.h */,
-				AEAA43D21A5F4CBE0034358B /* GlanceController.m */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -765,6 +770,7 @@
 				B83C32581A4CE18C0021F1A4 /* WKInterfaceTimerSpec.mm in Sources */,
 				AE85C0641A40A4F4009A0E4D /* SliderController.m in Sources */,
 				AEAA43D31A5F4CBE0034358B /* GlanceController.m in Sources */,
+				AE0FDC801A6ECB71006C781D /* CustomCategoryNotificationController.m in Sources */,
 				B83C32541A4CE18C0021F1A4 /* WKInterfaceObjectSpec.mm in Sources */,
 				AEB03EDE1A3FB366002404BC /* MapController.m in Sources */,
 				B83C324E1A4CE18C0021F1A4 /* WKInterfaceControllerSpec.mm in Sources */,

--- a/WatchKit/WatchKit/PCKInterfaceControllerLoader.h
+++ b/WatchKit/WatchKit/PCKInterfaceControllerLoader.h
@@ -8,7 +8,8 @@
                                      bundle:(NSBundle *)bundle;
 
 - (id)dynamicNotificationInterfaceControllerWithStoryboardName:(NSString *)storyboardName
-                                                        bundle:(NSBundle *)bundle;
+                                                        bundle:(NSBundle *)bundle
+                                          notificationCategory:(NSString *)notificationCategory;
 
 - (id)glanceInterfaceControllerWithStoryboardName:(NSString *)storyboardName
                                        identifier:(NSString *)objectID

--- a/WatchKit/WatchKit/PCKInterfaceControllerLoader.m
+++ b/WatchKit/WatchKit/PCKInterfaceControllerLoader.m
@@ -33,6 +33,7 @@
 
 - (id)dynamicNotificationInterfaceControllerWithStoryboardName:(NSString *)storyboardName
                                                         bundle:(NSBundle *)bundle
+                                          notificationCategory:(NSString *)notificationCategory
 {
     NSString *processedStoryboardName = [storyboardName stringByAppendingString:@"-notification"];
     NSString *pathForPlist = [bundle pathForResource:processedStoryboardName ofType:@"plist"];
@@ -45,7 +46,8 @@
 
     NSDictionary *serializedNotificationControllerStoryboard = [NSDictionary dictionaryWithContentsOfFile:pathForPlist];
 
-    NSDictionary *controllerProperties = serializedNotificationControllerStoryboard[@"categories"][@"default"][@"dynamic"];
+    NSString *categoryKey = notificationCategory ? notificationCategory : @"default";
+    NSDictionary *controllerProperties = serializedNotificationControllerStoryboard[@"categories"][categoryKey][@"dynamic"];
     PCKDynamicWatchKitObjectProvider *provider = [[PCKDynamicWatchKitObjectProvider alloc] init];
 
     return [provider interfaceControllerWithProperties:controllerProperties];


### PR DESCRIPTION
Added ability to instantiate WKUserNotificationInterfaceController subclasses configured for specific notification categories.  Wasn't sure if leaving PCKInterfaceControlelrLoader's existing interface in place and adding an overload was preferable to mutating the existing interface to now accept notificationCategory.