### PR TITLE
Gesture recognizer stubs report possible and ended state

### DIFF
--- a/UIKit/Spec/Extensions/UIGestureRecognizerSpec+Spec.mm
+++ b/UIKit/Spec/Extensions/UIGestureRecognizerSpec+Spec.mm
@@ -58,6 +58,38 @@ describe(@"UIGestureRecognizerSpec", ^{
             });
         });
 
+        describe(@"managing state", ^{
+            __block UIGestureRecognizerState capturedState;
+
+            beforeEach(^{
+                target stub_method(@selector(ciao:)).and_do_block(^(UIGestureRecognizer *gestureRecognizer) {
+                    capturedState = gestureRecognizer.state;
+                });
+                [recognizer addTarget:target action:@selector(ciao:)];
+            });
+
+            context(@"before the recognizer has recognized a gesture", ^{
+                it(@"should have the UIGestureRecognizerStatePossible state", ^{
+                    recognizer.state should equal(UIGestureRecognizerStatePossible);
+                });
+            });
+
+            context(@"once the recoginzer has recognized a gesture, while the actions are being performed", ^{
+                it(@"should have the UIGestureRecognizerStateRecognized state", ^{
+                    [recognizer recognize];
+                    capturedState should equal(UIGestureRecognizerStateRecognized);
+                    capturedState should equal(UIGestureRecognizerStateEnded);
+                });
+            });
+
+            context(@"once the recognizer has completed recognizing a gesture", ^{
+                it(@"should reset the state to UIGestureRecognizerStatePossible", ^{
+                    [recognizer recognize];
+                    recognizer.state should equal(UIGestureRecognizerStatePossible);
+                });
+            });
+        });
+
         describe(@"when additional targets are set", ^{
             __block Target *newTarget;
             beforeEach(^{

--- a/UIKit/SpecHelper/Stubs/UIGestureRecognizer+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIGestureRecognizer+Spec.m
@@ -12,6 +12,8 @@
 - (void)addSnoopedTarget:(id)target action:(SEL)action;
 - (void)removeUnswizzledTarget:(id)target action:(SEL)action;
 - (void)removeSnoopedTarget:(id)target action:(SEL)action;
+- (UIGestureRecognizerState)snoopedState;
+- (UIGestureRecognizerState)unswizzledState;
 - (instancetype)initWithoutSwizzledTarget:(id)target action:(SEL)action;
 - (instancetype)initWithSwizzledTarget:(id)target action:(SEL)action;
 
@@ -43,6 +45,11 @@
                                  forClass:[UIGestureRecognizer class]
                                        to:@selector(initWithSwizzledTarget:action:)
                             andRenameItTo:@selector(initWithoutSwizzledTarget:action:)];
+
+    [PCKMethodRedirector redirectSelector:@selector(state)
+                                 forClass:[UIGestureRecognizer class]
+                                       to:@selector(snoopedState)
+                            andRenameItTo:@selector(unswizzledState)];
 }
 
 + (instancetype)targetActionPairWithTarget:(id)target action:(SEL)action {
@@ -60,6 +67,7 @@
 
 - (instancetype)initWithSwizzledTarget:(id)target action:(SEL)action {
     if (self = [self initWithoutSwizzledTarget:target action:action]) {
+        [self setSnoopedState:UIGestureRecognizerStatePossible];
         if (target && action) {
             [self addSnoopedTarget:target action:action];
         }
@@ -77,9 +85,11 @@
         [[NSException exceptionWithName:@"Unrecognizable" reason:@"Can't recognize when recognizer is disabled" userInfo:nil] raise];
     }
 
+    [self setSnoopedState:UIGestureRecognizerStateEnded];
     [self.targetsAndActions enumerateObjectsUsingBlock:^(PCKGestureRecognizerTargetActionPair *targetActionPair, NSUInteger index, BOOL *stop) {
         [targetActionPair.target performSelector:targetActionPair.action withObject:self];
     }];
+    [self setSnoopedState:UIGestureRecognizerStatePossible];
 }
 
 + (void)whitelistClassForGestureSnooping:(Class)klass {}
@@ -106,6 +116,7 @@
 #pragma mark - Targets and Actions
 
 static char TARGETS_AND_ACTIONS_KEY;
+static char GESTURE_RECOGNIZER_STATE_KEY;
 
 - (NSMutableArray *)targetsAndActions {
     NSMutableArray *targetsAndActions = objc_getAssociatedObject(self, &TARGETS_AND_ACTIONS_KEY);
@@ -118,6 +129,14 @@ static char TARGETS_AND_ACTIONS_KEY;
 
 - (void)setTargetsAndActions:(NSMutableArray *)targetsAndActions {
     objc_setAssociatedObject(self, &TARGETS_AND_ACTIONS_KEY, targetsAndActions, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (UIGestureRecognizerState)snoopedState {
+    return (UIGestureRecognizerState)[(NSNumber *)objc_getAssociatedObject(self, &GESTURE_RECOGNIZER_STATE_KEY) integerValue];
+}
+
+- (void)setSnoopedState:(UIGestureRecognizerState)newState {
+    objc_setAssociatedObject(self, &GESTURE_RECOGNIZER_STATE_KEY, @(newState), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end


### PR DESCRIPTION
[Finishes #69288546]

Comments:
A discrete UIGestureRecognizer transitions from UIGestureRecognizerStatePossible to UIGestureRecognizerStateRecognized while in the process of sending its action messages to its targets, after which it resets its state to UIGestureRecognizerStatePossible. This PR simulates this behavior.