### PR TITLE
Add spec helper for CLLocationManager auth status

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -3,6 +3,7 @@
 ## 0.2.4 (in progress)
 
   * Adds instructions for releasing new versions of PivotalCoreKit
+  * Adds a stub for setting [CLLocationManager +authorizationStatus]
 
 ## 0.2.3
 

--- a/CoreLocation/CoreLocation.xcodeproj/project.pbxproj
+++ b/CoreLocation/CoreLocation.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8493636C1A9585E2005613BA /* CLLocationManagerSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 849363601A9585D2005613BA /* CLLocationManagerSpec+Spec.mm */; };
+		849363731A9588AD005613BA /* CLLocationManagerSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 849363601A9585D2005613BA /* CLLocationManagerSpec+Spec.mm */; };
+		849363C01A9758D5005613BA /* CLLocationManager+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8493636E1A958640005613BA /* CLLocationManager+Spec.m */; };
+		849363C11A9758EE005613BA /* CLLocationManager+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8493636E1A958640005613BA /* CLLocationManager+Spec.m */; };
 		AE118AE718D6BC2F00C90D6B /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE3848DD168CD86000C99B55 /* CoreGraphics.framework */; };
 		AE118AE818D6BC2F00C90D6B /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE3848D9168CD86000C99B55 /* UIKit.framework */; };
 		AE118AE918D6BC2F00C90D6B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE3848DB168CD86000C99B55 /* Foundation.framework */; };
@@ -180,6 +184,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		849363601A9585D2005613BA /* CLLocationManagerSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "CLLocationManagerSpec+Spec.mm"; sourceTree = "<group>"; };
+		8493636D1A958640005613BA /* CLLocationManager+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CLLocationManager+Spec.h"; sourceTree = "<group>"; };
+		8493636E1A958640005613BA /* CLLocationManager+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CLLocationManager+Spec.m"; sourceTree = "<group>"; };
 		AE118AE418D6BC2F00C90D6B /* CoreLocation-StaticLibSpecBundle.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CoreLocation-StaticLibSpecBundle.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE118AE518D6BC2F00C90D6B /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		AE118AEC18D6BC2F00C90D6B /* CoreLocation-StaticLibSpecBundle-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "CoreLocation-StaticLibSpecBundle-Info.plist"; sourceTree = "<group>"; };
@@ -342,6 +349,8 @@
 			children = (
 				AE38494D168CD9B600C99B55 /* CLGeocoder+Spec.h */,
 				AE38494E168CD9B600C99B55 /* CLGeocoder+Spec.m */,
+				8493636D1A958640005613BA /* CLLocationManager+Spec.h */,
+				8493636E1A958640005613BA /* CLLocationManager+Spec.m */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -360,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				AEC81173168D14FF00523186 /* CLGeocoderSpec+Spec.mm */,
+				849363601A9585D2005613BA /* CLLocationManagerSpec+Spec.mm */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -669,6 +679,7 @@
 			files = (
 				AE384961168D032300C99B55 /* main.m in Sources */,
 				AE49474D168D15C9006F3B70 /* CLGeocoderSpec+Spec.mm in Sources */,
+				8493636C1A9585E2005613BA /* CLLocationManagerSpec+Spec.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -676,6 +687,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				849363C01A9758D5005613BA /* CLLocationManager+Spec.m in Sources */,
 				AE384952168CD9B600C99B55 /* CLGeocoder+Spec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -684,6 +696,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				849363731A9588AD005613BA /* CLLocationManagerSpec+Spec.mm in Sources */,
 				AE384960168D030800C99B55 /* main.m in Sources */,
 				AE494744168D15C8006F3B70 /* CLGeocoderSpec+Spec.mm in Sources */,
 			);
@@ -693,6 +706,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				849363C11A9758EE005613BA /* CLLocationManager+Spec.m in Sources */,
 				AE38499B168D056600C99B55 /* CLGeocoder+Spec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CoreLocation/Spec/Extensions/CLLocationManagerSpec+Spec.mm
+++ b/CoreLocation/Spec/Extensions/CLLocationManagerSpec+Spec.mm
@@ -1,0 +1,29 @@
+#import <Foundation/Foundation.h>
+#if TARGET_OS_IPHONE
+#import "CDRSpecHelper.h"
+#else
+#import <Cedar/CDRSpecHelper.h>
+#endif
+#import "CLLocationManager+Spec.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(CLLocationManagerSpec)
+
+describe(@"CLLocationManager", ^{
+    describe(@"overriding the authorization status", ^{
+        beforeEach(^{
+            // It is impossible to set the status to restricted on the simulator.
+            [CLLocationManager authorizationStatus] should_not equal(kCLAuthorizationStatusRestricted);
+
+            [CLLocationManager setAuthorizationStatus:kCLAuthorizationStatusRestricted];
+        });
+
+        it(@"should return the newly set status", ^{
+            [CLLocationManager authorizationStatus] should equal(kCLAuthorizationStatusRestricted);
+        });
+    });
+});
+
+SPEC_END

--- a/CoreLocation/SpecHelper/CoreLocation+PivotalSpecHelper.h
+++ b/CoreLocation/SpecHelper/CoreLocation+PivotalSpecHelper.h
@@ -1,1 +1,2 @@
+#import "CLLocationManager+Spec.h"
 #import "CLGeocoder+Spec.h"

--- a/CoreLocation/SpecHelper/Extensions/CLLocationManager+Spec.h
+++ b/CoreLocation/SpecHelper/Extensions/CLLocationManager+Spec.h
@@ -1,0 +1,7 @@
+#import <CoreLocation/CoreLocation.h>
+
+@interface CLLocationManager (Spec)
+
++ (void)setAuthorizationStatus:(CLAuthorizationStatus)authorizationStatus;
+
+@end

--- a/CoreLocation/SpecHelper/Extensions/CLLocationManager+Spec.m
+++ b/CoreLocation/SpecHelper/Extensions/CLLocationManager+Spec.m
@@ -1,0 +1,46 @@
+#import "CLLocationManager+Spec.h"
+#import "objc/runtime.h"
+
+static char kAuthorizationKey;
+
+@interface CLLocationManager ()
++ (CLAuthorizationStatus)original_authorizationStatus;
+@end
+
+@implementation CLLocationManager (Spec)
+
++ (void)load {
+    [self redirectClassSelector:@selector(authorizationStatus)
+                             to:@selector(stubbed_authorizationStatus)
+                  andRenameItTo:@selector(original_authorizationStatus)];
+}
+
++ (CLAuthorizationStatus)stubbed_authorizationStatus {
+    return [objc_getAssociatedObject(self, &kAuthorizationKey) intValue];
+}
+
++ (void)setAuthorizationStatus:(CLAuthorizationStatus)authorizationStatus {
+    objc_setAssociatedObject(self, &kAuthorizationKey, @(authorizationStatus), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+#pragma mark - TODO Refactor to use code in Foundation project
++ (void)redirectClassSelector:(SEL)originalSelector to:(SEL)newSelector andRenameItTo:(SEL)renamedSelector {
+    [self redirectSelector:originalSelector
+                  forClass:objc_getMetaClass(class_getName([self class]))
+                        to:newSelector
+             andRenameItTo:renamedSelector];
+}
+
++ (void)redirectSelector:(SEL)originalSelector forClass:(Class)klass to:(SEL)newSelector andRenameItTo:(SEL)renamedSelector {
+    if ([klass instancesRespondToSelector:renamedSelector]) {
+        return;
+    }
+
+    Method originalMethod = class_getInstanceMethod(klass, originalSelector);
+    class_addMethod(klass, renamedSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod));
+
+    Method newMethod = class_getInstanceMethod(klass, newSelector);
+    class_replaceMethod(klass, originalSelector, method_getImplementation(newMethod), method_getTypeEncoding(newMethod));
+}
+
+@end


### PR DESCRIPTION
This PR opens up the class method `+authorizationStatus` on `CLLocationManager` with `+setAuthorizationStatus:`.

It uses the same method swizzling used in Foundation and UIKit subpods and follows the same convention of copying over the code as UIKit does. This should be refactored into a shared location, perhaps having UIKit and CoreLocation depend on Foundation? I'm not 100% sure how that works with sub pod specs and any thoughts are appreciated.