### PR TITLE
Use -performSelector: instead of objc_msgSend()

### DIFF
--- a/UIKit/SpecHelper/Extensions/UIBarButtonItem+Spec.m
+++ b/UIKit/SpecHelper/Extensions/UIBarButtonItem+Spec.m
@@ -1,6 +1,5 @@
 #import "UIBarButtonItem+Spec.h"
 #import "UIControl+Spec.h"
-#import <objc/message.h>
 
 
 @implementation UIBarButtonItem (Spec)
@@ -15,9 +14,7 @@
         UIButton *button = (UIButton *)self.customView;
         [button tap];
     } else {
-        id target = self.target;
-        SEL action = self.action;
-        objc_msgSend(target, action, nil);
+        [self.target performSelector:self.action];
     }
 }
 


### PR DESCRIPTION
Avoids warnings and errors related to not casting objc_msgSend() to a
function prototype matching the target selector on 64-bit platforms.

Since this code has to support different signatures (the action selector
may or may not accept an argument), -performSelector: is used.

For more excruciating detail, see:
https://developer.apple.com/library/ios/documentation/General/Conceptual/CocoaTouch64BitGuide/ConvertingYourAppto64-Bit/ConvertingYourAppto64-Bit.html#//apple_ref/doc/uid/TP40013501-CH3-SW26