### PR TITLE
-[UIBarButtonItem tap] passes itself as sender

### DIFF
--- a/UIKit/Spec/Extensions/UIBarButtonItemSpec+Spec.mm
+++ b/UIKit/Spec/Extensions/UIBarButtonItemSpec+Spec.mm
@@ -2,10 +2,8 @@
 #import "UIBarButtonItem+Spec.h"
 #import "Target.h"
 
-
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
-
 
 SPEC_BEGIN(UIBarButtonItemSpec_Spec)
 
@@ -29,18 +27,27 @@ describe(@"UIBarButtonItemSpec_Spec", ^{
 
     it(@"should throw an exception if the bar button item is disabled", ^{
         barButtonItem.enabled = NO;
-        expect(^{[barButtonItem tap];}).to(raise_exception());
+        ^{ [barButtonItem tap]; } should raise_exception;
+    });
+
+    it(@"should pass itself as sender if the action selector takes an argument", ^{
+        barButtonItem = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+                                                                       target:target
+                                                                       action:@selector(ciao:)] autorelease];
+        [barButtonItem tap];
+        target should have_received(@selector(ciao:)).with(barButtonItem);
     });
 
     it(@"should delegate down to the custom view if the custom view is a button", ^{
         UIButton *button = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-        [button addTarget:target action:@selector(hello) forControlEvents:UIControlEventTouchUpInside];
+        [button addTarget:target
+                   action:@selector(hello)
+         forControlEvents:UIControlEventTouchUpInside];
         barButtonItem = [[[UIBarButtonItem alloc] initWithCustomView:button] autorelease];
         [barButtonItem tap];
 
         target should have_received(@selector(hello));
     });
-
 });
 
 SPEC_END

--- a/UIKit/SpecHelper/Extensions/UIBarButtonItem+Spec.m
+++ b/UIKit/SpecHelper/Extensions/UIBarButtonItem+Spec.m
@@ -1,11 +1,9 @@
 #import "UIBarButtonItem+Spec.h"
 #import "UIControl+Spec.h"
 
-
 @implementation UIBarButtonItem (Spec)
 
-- (void)tap
-{
+- (void)tap {
     if (self.enabled == NO) {
         @throw @"Attempted to tap disabled bar button item";
     }
@@ -14,7 +12,7 @@
         UIButton *button = (UIButton *)self.customView;
         [button tap];
     } else {
-        [self.target performSelector:self.action];
+        [self.target performSelector:self.action withObject:self];
     }
 }
 


### PR DESCRIPTION
Fixes crash when the action on the target receives the sender

Looks like the #125 which was merged yesterday crashes in this situation.