### PR TITLE
Clean up UIKit spec output

### DIFF
--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
@@ -27,7 +27,9 @@
 
     UIAlertAction *cancelAction = [[self.actions filteredArrayUsingPredicate:cancelPredicate] lastObject];
     if (self.preferredStyle == UIAlertControllerStyleActionSheet) {
-        NSAssert(cancelAction, @"UIAlertController does not have a cancel button");
+        if (!cancelAction) {
+            [[NSException exceptionWithName:NSInternalInconsistencyException reason:@"UIAlertController does not have a cancel button" userInfo:nil] raise];
+        }
         return cancelAction;
     } else {
         return cancelAction ? cancelAction : self.actions.lastObject;
@@ -37,7 +39,10 @@
 - (UIAlertAction *)actionWithButtonTitle:(NSString *)title {
     NSArray *buttonTitles = [self.actions valueForKey:@"title"];
     NSUInteger buttonIndex = [buttonTitles indexOfObject:title];
-    NSAssert((buttonIndex != NSNotFound), @"UIAlertController does not have a button titled '%@' -- current button titles are %@", title, buttonTitles);
+    if (buttonIndex == NSNotFound) {
+        NSString *reason = [NSString stringWithFormat:@"UIAlertController does not have a button titled '%@' -- current button titles are %@", title, buttonTitles];
+        [[NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil] raise];
+    }
     return self.actions[buttonIndex];
 }
 


### PR DESCRIPTION
Running UIKit specs logs out assertion failures due to the tests hitting code paths that expectedly fail assertions. Using an NSException achieves the same desired behavior but without the logging noise.

I only changed this one example because the tests trigger this code path. Other `NSAssert`s in the codebase are not triggered via spec so do not need to be changed.