### PR TITLE
Call additional private method in -[UITableViewCell tap]

### DIFF
--- a/UIKit/Spec/Extensions/UITableViewCellSpec+Spec.mm
+++ b/UIKit/Spec/Extensions/UITableViewCellSpec+Spec.mm
@@ -3,6 +3,19 @@
 #import "PrototypeCellObjects.h"
 
 
+@interface BasicSpecTableViewCell : UITableViewCell
+@property (nonatomic, assign) NSInteger numberOfSelectedYesCalls;
+@end
+
+@implementation BasicSpecTableViewCell
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+    if (selected) {
+        ++self.numberOfSelectedYesCalls;
+    }
+}
+@end
+
 @interface SpecTableViewController : UITableViewController
 @property (nonatomic) BOOL shouldHightlightRows;
 @property (nonatomic, retain) NSIndexPath *lastSelectedIndexPath;
@@ -12,7 +25,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:@"Cell"];
+    [self.tableView registerClass:[BasicSpecTableViewCell class] forCellReuseIdentifier:@"Cell"];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
@@ -45,7 +58,7 @@ SPEC_BEGIN(UITableViewCell_SpecSpec)
 
 describe(@"UITableViewCell+Spec", ^{
     __block SpecTableViewController *controller;
-    __block UITableViewCell *cell;
+    __block BasicSpecTableViewCell *cell;
 
     beforeEach(^{
         controller = [[[SpecTableViewController alloc] initWithStyle:UITableViewStylePlain] autorelease];
@@ -64,6 +77,10 @@ describe(@"UITableViewCell+Spec", ^{
 
             it(@"should result in the cell being selected", ^{
                 [controller.tableView indexPathForSelectedRow] should equal([controller.tableView indexPathForCell:cell]);
+            });
+
+            it(@"should call -setSelected:animated: twice on the cell because that's what a real UITableView does when a user taps a cell", ^{
+                cell.numberOfSelectedYesCalls should equal(2);
             });
 
             it(@"should highlight the cell", ^{

--- a/UIKit/SpecHelper/Extensions/UITableViewCell+Spec.m
+++ b/UIKit/SpecHelper/Extensions/UITableViewCell+Spec.m
@@ -12,6 +12,7 @@
 - (BOOL)highlightRowAtIndexPath:(id)arg1 animated:(BOOL)arg2 scrollPosition:(int)arg3;
 - (void)unhighlightRowAtIndexPath:(id)arg1 animated:(BOOL)arg2;
 - (void)_selectRowAtIndexPath:(id)arg1 animated:(BOOL)arg2 scrollPosition:(int)arg3 notifyDelegate:(BOOL)arg4;
+- (void)_selectAllSelectedRows;
 - (void)_deselectRowAtIndexPath:(id)arg1 animated:(BOOL)arg2 notifyDelegate:(BOOL)arg3;
 @end
 
@@ -46,6 +47,7 @@
             [tableView _deselectRowAtIndexPath:indexPath animated:NO notifyDelegate:YES];
         } else {
             [tableView _selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionMiddle notifyDelegate:YES];
+            [tableView _selectAllSelectedRows];
         }
     }
 }


### PR DESCRIPTION
To better match UITableView's tap behavior, which calls -setSelected:animated: a second time.