### PR TITLE
Added a way to run operations in specs when set to run synchronously. Al...

### DIFF
--- a/Foundation/SpecHelper/Fakes/PSHKFakeOperationQueue.m
+++ b/Foundation/SpecHelper/Fakes/PSHKFakeOperationQueue.m
@@ -36,11 +36,17 @@
         if (![operation isKindOfClass:[NSOperation class]]) {
             operation = [NSBlockOperation blockOperationWithBlock:[[operation copy] autorelease]];
         }
-
+        
         if (wait) {
             [self performOperationAndWait:operation];
         } else {
             [self.mutableOperations addObject:operation];
+        }
+    }
+    
+    if (self.runSynchronously) {
+        for (NSOperation *operation in self.operations) {
+            [self performOperationAndWait:operation];
         }
     }
 }
@@ -78,6 +84,12 @@
         ((void (^)())operation)();
     }
     [self.mutableOperations removeObject:operation];
+}
+
+- (void)cancelAllOperations {
+    for (NSOperation *op in self.operations) {
+        [op cancel];
+    }
 }
 
 @end


### PR DESCRIPTION
...so added an appropriate override for canceling operations since it looks like the super implementation is not being called. (verified by seeing if my operation's cancel method was called after calling -[PSHKFakeOperationQueue cancellAllOperations]--it wasn't).