### PR TITLE
add support for WKInterfaceDevice, and class methods in WKInterfaceController

### DIFF
--- a/WatchKit/Specs/WatchKit/WKInterfaceControllerSpec.mm
+++ b/WatchKit/Specs/WatchKit/WKInterfaceControllerSpec.mm
@@ -2,7 +2,7 @@
 #import "CorgisController.h"
 #import "InterfaceController.h"
 #import "PCKInterfaceControllerLoader.h"
-
+#import "NSInvocation+InvocationMatching.h"
 
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
@@ -194,6 +194,50 @@ describe(@"WKInterfaceController", ^{
             [subject updateUserActivity:@"asdf" userInfo:@{@"a": @"b"}];
 
             subject should have_received(@selector(updateUserActivity:userInfo:)).with(@"asdf", @{@"a": @"b"});
+        });
+    });
+
+    describe(@"class methods", ^{
+
+        context(@"openParentApplication:reply:", ^{
+            typedef void (^ReplyBlock)(NSDictionary *, NSError *);
+            __block NSDictionary *userInfo;
+            __block ReplyBlock reply;
+
+            beforeEach(^{
+                userInfo = @{ @"user" : @"info" };
+                reply = ^void(NSDictionary *replyInfo, NSError *error) { };
+            });
+
+            it(@"should have recorded invocations", ^{
+                [subject.class openParentApplication:userInfo
+                                               reply:reply];
+                NSInvocation *invocation = [[PCKMessageCapturer sent_class_messages] firstObject];
+                [invocation matchesTarget:subject.class
+                                 selector:@selector(openParentApplication:reply:)
+                                arguments:@[userInfo, reply]] should be_truthy;
+
+            });
+        });
+
+        context(@"reloadRootControllersWithNames:contexts:", ^{
+            __block NSArray *names;
+            __block NSArray *contexts;
+
+            beforeEach(^{
+                names = @[@"name-one", @"name-two", @"name-three"];
+                contexts = @[@"context-one", @"context-two"];
+            });
+
+            it(@"should have recorded invocations", ^{
+                [subject.class reloadRootControllersWithNames:names
+                                                     contexts:contexts];
+
+                NSInvocation *invocation = [[PCKMessageCapturer sent_class_messages] firstObject];
+                [invocation matchesTarget:subject.class
+                                 selector:@selector(reloadRootControllersWithNames:contexts:)
+                                arguments:@[names, contexts]] should be_truthy;
+            });
         });
     });
 

--- a/WatchKit/Specs/WatchKit/WKInterfaceDeviceSpec.mm
+++ b/WatchKit/Specs/WatchKit/WKInterfaceDeviceSpec.mm
@@ -1,0 +1,66 @@
+#import "Cedar.h"
+#import "WKInterfaceDevice.h"
+#import "NSInvocation+InvocationMatching.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(WKInterfaceDeviceSpec)
+
+describe(@"WKInterfaceDevice", ^{
+    __block WKInterfaceDevice *subject;
+
+    beforeEach(^{
+        subject = [[WKInterfaceDevice alloc] init];
+    });
+
+    describe(@"public methods", ^{
+        __block NSString *name;
+
+        beforeEach(^{
+            name = @"image-name";
+        });
+
+        it(@"should record the invocation for addCachedImage:name:", ^{
+            UIImage *image = [[UIImage alloc] init];
+
+            [subject addCachedImage:image name:name];
+
+            subject should have_received(@selector(addCachedImage:name:))
+            .with(image, name);
+        });
+
+        it(@"should record the invocation for addCachedImageWithData:name:", ^{
+            NSData *imageData = [[NSData alloc] init];
+            [subject addCachedImageWithData:imageData name:name];
+
+            subject should have_received(@selector(addCachedImageWithData:name:))
+            .with(imageData, name);
+        });
+
+        it(@"should record the invocation removeCachedImageWithName:", ^{
+            [subject removeCachedImageWithName:name];
+
+            subject should have_received(@selector(removeCachedImageWithName:))
+            .with(name);
+        });
+
+        it(@"should record the invocation for removeAllCachedImages", ^{
+            [subject removeAllCachedImages];
+
+            subject should have_received(@selector(removeAllCachedImages));
+        });
+    });
+
+    describe(@"class methods", ^{
+        it(@"should record the invocation for currentDevice", ^{
+            [WKInterfaceDevice currentDevice];
+            NSInvocation *invocation = [[PCKMessageCapturer sent_class_messages] firstObject];
+            [invocation matchesTarget:subject.class
+                             selector:@selector(currentDevice)
+                            arguments:nil] should be_truthy;
+        });
+    });
+});
+
+SPEC_END

--- a/WatchKit/WatchKit.xcodeproj/project.pbxproj
+++ b/WatchKit/WatchKit.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		267B25B21AD86BDB00440CD2 /* NSInvocation+InvocationMatching.h in Headers */ = {isa = PBXBuildFile; fileRef = 267B25B01AD86BDB00440CD2 /* NSInvocation+InvocationMatching.h */; };
 		267B25B31AD86BDB00440CD2 /* NSInvocation+InvocationMatching.m in Sources */ = {isa = PBXBuildFile; fileRef = 267B25B11AD86BDB00440CD2 /* NSInvocation+InvocationMatching.m */; };
+		2681A5B11AE0906600B0B753 /* WKInterfaceDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 2681A5AF1AE0906600B0B753 /* WKInterfaceDevice.m */; };
+		2681A5B21AE0906600B0B753 /* WKInterfaceDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 2681A5B01AE0906600B0B753 /* WKInterfaceDevice.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2681A5D31AE0991C00B0B753 /* WKInterfaceDeviceSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2681A5D21AE0991C00B0B753 /* WKInterfaceDeviceSpec.mm */; };
 		AE03A0391A391C5900AD4964 /* corgi.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = AE03A0381A391C5900AD4964 /* corgi.jpeg */; };
 		AE0FDC801A6ECB71006C781D /* CustomCategoryNotificationController.m in Sources */ = {isa = PBXBuildFile; fileRef = AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */; };
 		AE25D5FE1A38F6C9008A1920 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D5FD1A38F6C9008A1920 /* XCTest.framework */; };
@@ -198,6 +201,9 @@
 /* Begin PBXFileReference section */
 		267B25B01AD86BDB00440CD2 /* NSInvocation+InvocationMatching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSInvocation+InvocationMatching.h"; sourceTree = "<group>"; };
 		267B25B11AD86BDB00440CD2 /* NSInvocation+InvocationMatching.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSInvocation+InvocationMatching.m"; sourceTree = "<group>"; };
+		2681A5AF1AE0906600B0B753 /* WKInterfaceDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WKInterfaceDevice.m; sourceTree = "<group>"; };
+		2681A5B01AE0906600B0B753 /* WKInterfaceDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKInterfaceDevice.h; sourceTree = "<group>"; };
+		2681A5D21AE0991C00B0B753 /* WKInterfaceDeviceSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKInterfaceDeviceSpec.mm; path = Specs/WatchKit/WKInterfaceDeviceSpec.mm; sourceTree = SOURCE_ROOT; };
 		AE03A0381A391C5900AD4964 /* corgi.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = corgi.jpeg; sourceTree = "<group>"; };
 		AE0FDC7E1A6ECB71006C781D /* CustomCategoryNotificationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomCategoryNotificationController.h; sourceTree = "<group>"; };
 		AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomCategoryNotificationController.m; sourceTree = "<group>"; };
@@ -328,6 +334,7 @@
 				B83C323F1A4CE18C0021F1A4 /* WKInterfaceButtonSpec.mm */,
 				B83C32401A4CE18C0021F1A4 /* WKInterfaceControllerSpec.mm */,
 				B83C32411A4CE18C0021F1A4 /* WKInterfaceDateSpec.mm */,
+				2681A5D21AE0991C00B0B753 /* WKInterfaceDeviceSpec.mm */,
 				B83C32421A4CE18C0021F1A4 /* WKInterfaceGroupSpec.mm */,
 				B83C32431A4CE18C0021F1A4 /* WKInterfaceImageSpec.mm */,
 				B83C32441A4CE18C0021F1A4 /* WKInterfaceLabelSpec.mm */,
@@ -477,6 +484,8 @@
 				B83C31E41A4CD9BF0021F1A4 /* WKInterfaceDate.h */,
 				B83C31E51A4CD9BF0021F1A4 /* WKInterfaceDate.m */,
 				B83C31E61A4CD9BF0021F1A4 /* WKInterfaceDate+Spec.h */,
+				2681A5B01AE0906600B0B753 /* WKInterfaceDevice.h */,
+				2681A5AF1AE0906600B0B753 /* WKInterfaceDevice.m */,
 				B83C31E71A4CD9BF0021F1A4 /* WKInterfaceGroup.h */,
 				B83C31E81A4CD9BF0021F1A4 /* WKInterfaceGroup.m */,
 				B83C31E91A4CD9BF0021F1A4 /* WKInterfaceGroup+Spec.h */,
@@ -551,6 +560,7 @@
 				B83C32211A4CD9BF0021F1A4 /* WKInterfaceSlider+Spec.h in Headers */,
 				B83C321F1A4CD9BF0021F1A4 /* WKInterfaceSlider.h in Headers */,
 				B83C32171A4CD9BF0021F1A4 /* WKInterfaceLabel+Spec.h in Headers */,
+				2681A5B21AE0906600B0B753 /* WKInterfaceDevice.h in Headers */,
 				267B25B21AD86BDB00440CD2 /* NSInvocation+InvocationMatching.h in Headers */,
 				B83C32181A4CD9BF0021F1A4 /* WKInterfaceMap.h in Headers */,
 				B83C320E1A4CD9BF0021F1A4 /* WKInterfaceDate+Spec.h in Headers */,
@@ -785,6 +795,7 @@
 				B83C32571A4CE18C0021F1A4 /* WKInterfaceTableSpec.mm in Sources */,
 				B83C32531A4CE18C0021F1A4 /* WKInterfaceMapSpec.mm in Sources */,
 				B83C32511A4CE18C0021F1A4 /* WKInterfaceImageSpec.mm in Sources */,
+				2681A5D31AE0991C00B0B753 /* WKInterfaceDeviceSpec.mm in Sources */,
 				AE85C0611A3FC03B009A0E4D /* GroupController.m in Sources */,
 				B83C324C1A4CE18C0021F1A4 /* PCKInterfaceControllerLoaderSpec.mm in Sources */,
 				AED5709C1A3A4786004ABADA /* CorgisController.m in Sources */,
@@ -818,6 +829,7 @@
 				267B25B31AD86BDB00440CD2 /* NSInvocation+InvocationMatching.m in Sources */,
 				B83C32191A4CD9BF0021F1A4 /* WKInterfaceMap.m in Sources */,
 				B83C32131A4CD9BF0021F1A4 /* WKInterfaceImage.m in Sources */,
+				2681A5B11AE0906600B0B753 /* WKInterfaceDevice.m in Sources */,
 				B83C32081A4CD9BF0021F1A4 /* WKInterfaceButton.m in Sources */,
 				B83C320B1A4CD9BF0021F1A4 /* WKInterfaceController.m in Sources */,
 			);

--- a/WatchKit/WatchKit.xcodeproj/project.pbxproj
+++ b/WatchKit/WatchKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		267B25B21AD86BDB00440CD2 /* NSInvocation+InvocationMatching.h in Headers */ = {isa = PBXBuildFile; fileRef = 267B25B01AD86BDB00440CD2 /* NSInvocation+InvocationMatching.h */; };
+		267B25B31AD86BDB00440CD2 /* NSInvocation+InvocationMatching.m in Sources */ = {isa = PBXBuildFile; fileRef = 267B25B11AD86BDB00440CD2 /* NSInvocation+InvocationMatching.m */; };
 		AE03A0391A391C5900AD4964 /* corgi.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = AE03A0381A391C5900AD4964 /* corgi.jpeg */; };
 		AE0FDC801A6ECB71006C781D /* CustomCategoryNotificationController.m in Sources */ = {isa = PBXBuildFile; fileRef = AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */; };
 		AE25D5FE1A38F6C9008A1920 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D5FD1A38F6C9008A1920 /* XCTest.framework */; };
@@ -194,6 +196,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		267B25B01AD86BDB00440CD2 /* NSInvocation+InvocationMatching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSInvocation+InvocationMatching.h"; sourceTree = "<group>"; };
+		267B25B11AD86BDB00440CD2 /* NSInvocation+InvocationMatching.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSInvocation+InvocationMatching.m"; sourceTree = "<group>"; };
 		AE03A0381A391C5900AD4964 /* corgi.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = corgi.jpeg; sourceTree = "<group>"; };
 		AE0FDC7E1A6ECB71006C781D /* CustomCategoryNotificationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomCategoryNotificationController.h; sourceTree = "<group>"; };
 		AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomCategoryNotificationController.m; sourceTree = "<group>"; };
@@ -451,6 +455,8 @@
 		B83C31C21A4CD8A40021F1A4 /* WatchKit */ = {
 			isa = PBXGroup;
 			children = (
+				267B25B01AD86BDB00440CD2 /* NSInvocation+InvocationMatching.h */,
+				267B25B11AD86BDB00440CD2 /* NSInvocation+InvocationMatching.m */,
 				B83AC22B1A5E191C00A35BD6 /* PCKDynamicWatchKitObjectProvider.h */,
 				B83AC22C1A5E191C00A35BD6 /* PCKDynamicWatchKitObjectProvider.m */,
 				B83C322C1A4CDA380021F1A4 /* PCKFakeSegue.h */,
@@ -545,6 +551,7 @@
 				B83C32211A4CD9BF0021F1A4 /* WKInterfaceSlider+Spec.h in Headers */,
 				B83C321F1A4CD9BF0021F1A4 /* WKInterfaceSlider.h in Headers */,
 				B83C32171A4CD9BF0021F1A4 /* WKInterfaceLabel+Spec.h in Headers */,
+				267B25B21AD86BDB00440CD2 /* NSInvocation+InvocationMatching.h in Headers */,
 				B83C32181A4CD9BF0021F1A4 /* WKInterfaceMap.h in Headers */,
 				B83C320E1A4CD9BF0021F1A4 /* WKInterfaceDate+Spec.h in Headers */,
 				B83C32221A4CD9BF0021F1A4 /* WKInterfaceSwitch.h in Headers */,
@@ -808,6 +815,7 @@
 				B83C320D1A4CD9BF0021F1A4 /* WKInterfaceDate.m in Sources */,
 				B83C32101A4CD9BF0021F1A4 /* WKInterfaceGroup.m in Sources */,
 				B83C32231A4CD9BF0021F1A4 /* WKInterfaceSwitch.m in Sources */,
+				267B25B31AD86BDB00440CD2 /* NSInvocation+InvocationMatching.m in Sources */,
 				B83C32191A4CD9BF0021F1A4 /* WKInterfaceMap.m in Sources */,
 				B83C32131A4CD9BF0021F1A4 /* WKInterfaceImage.m in Sources */,
 				B83C32081A4CD9BF0021F1A4 /* WKInterfaceButton.m in Sources */,

--- a/WatchKit/WatchKit/NSInvocation+InvocationMatching.h
+++ b/WatchKit/WatchKit/NSInvocation+InvocationMatching.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface NSInvocation (InvocationMatching)
+
+- (BOOL)matchesTarget:(id)target selector:(SEL)selector arguments:(NSArray *)arguments;
+
+@end

--- a/WatchKit/WatchKit/NSInvocation+InvocationMatching.m
+++ b/WatchKit/WatchKit/NSInvocation+InvocationMatching.m
@@ -1,0 +1,32 @@
+#import "NSInvocation+InvocationMatching.h"
+
+@implementation NSInvocation (InvocationMatching)
+
+- (BOOL)matchesTarget:(id)target selector:(SEL)selector arguments:(NSArray *)arguments
+{
+    if (self.selector != selector) {
+        return NO;
+    }
+
+    if (self.target != target) {
+        return NO;
+    }
+
+    NSInteger selectorArgumentCount = self.methodSignature.numberOfArguments - 2;
+
+    if (selectorArgumentCount != arguments.count) {
+        return NO;
+    }
+
+    for(NSInteger idx = 0; idx < selectorArgumentCount; idx++) {
+        id argument = [arguments objectAtIndex:idx];
+        __unsafe_unretained id retrievedArg;
+        [self getArgument:&retrievedArg atIndex:idx + 2];
+        if(retrievedArg != argument && ![retrievedArg isEqual:argument]) {
+            return NO;
+        };
+    }
+
+    return YES;
+}
+@end

--- a/WatchKit/WatchKit/PCKMessageCapturer.h
+++ b/WatchKit/WatchKit/PCKMessageCapturer.h
@@ -4,5 +4,6 @@
 @interface PCKMessageCapturer : NSObject
 
 - (NSArray *)sent_messages;
++ (NSArray *)sent_class_messages;
 
 @end

--- a/WatchKit/WatchKit/PCKMessageCapturer.m
+++ b/WatchKit/WatchKit/PCKMessageCapturer.m
@@ -1,14 +1,14 @@
 #import "PCKMessageCapturer.h"
 
-
 @interface PCKMessageCapturer ()
 
 @property (nonatomic) NSMutableArray *sent_messages;
 
 @end
 
-
 @implementation PCKMessageCapturer
+
+static  NSMutableArray *sent_class_messages_array;
 
 #pragma mark - NSObject
 
@@ -25,6 +25,24 @@
 {
     [anInvocation retainArguments];
     [_sent_messages addObject:anInvocation];
+}
+
++ (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    if (!sent_class_messages_array) {
+        sent_class_messages_array = [NSMutableArray array];
+    }
+    [sent_class_messages_array addObject:anInvocation];
+}
+
++ (NSArray *)sent_class_messages
+{
+    return sent_class_messages_array;
+}
+
++ (void)afterEach
+{
+    sent_class_messages_array = [NSMutableArray array];
 }
 
 @end

--- a/WatchKit/WatchKit/WKInterfaceController.h
+++ b/WatchKit/WatchKit/WKInterfaceController.h
@@ -54,7 +54,7 @@ typedef enum WKTextInputMode : NSInteger  {
 - (void)popController;
 - (void)popToRootController;
 
-// TODO: + (void)reloadRootControllersWithNames:(NSArray *)names contexts:(NSArray *)contexts;
++ (void)reloadRootControllersWithNames:(NSArray *)names contexts:(NSArray *)contexts;
 - (void)becomeCurrentPage;
 
 - (void)presentControllerWithName:(NSString *)name context:(id)context;
@@ -78,7 +78,7 @@ typedef enum WKTextInputMode : NSInteger  {
 
 - (void)updateUserActivity:(NSString *)type userInfo:(NSDictionary *)userInfo;
 
-// TODO:+ (BOOL)openParentApplication:(NSDictionary *)userInfo reply:(void(^)(NSDictionary *replyInfo, NSError *error)) reply;
++ (BOOL)openParentApplication:(NSDictionary *)userInfo reply:(void(^)(NSDictionary *replyInfo, NSError *error)) reply;
 
 @end
 

--- a/WatchKit/WatchKit/WKInterfaceController.m
+++ b/WatchKit/WatchKit/WKInterfaceController.m
@@ -49,6 +49,9 @@
 - (void)didReceiveLocalNotification:(UILocalNotification *)localNotification
                      withCompletion:(void(^)(WKUserNotificationInterfaceType interface)) completionHandler NS_REQUIRES_SUPER;
 
++ (BOOL)openParentApplication:(NSDictionary *)userInfo reply:(void(^)(NSDictionary *replyInfo, NSError *error)) reply NS_REQUIRES_SUPER;
++ (void)reloadRootControllersWithNames:(NSArray *)names contexts:(NSArray *)contexts NS_REQUIRES_SUPER;
+
 @end
 
 
@@ -190,6 +193,16 @@
 - (void)updateUserActivity:(NSString *)type userInfo:(NSDictionary *)userInfo
 {
     [super updateUserActivity:type userInfo:userInfo];
+}
+
++ (BOOL)openParentApplication:(NSDictionary *)userInfo reply:(void(^)(NSDictionary *replyInfo, NSError *error)) reply
+{
+    return [super openParentApplication:userInfo reply:reply];
+}
+
++ (void)reloadRootControllersWithNames:(NSArray *)names contexts:(NSArray *)contexts
+{
+    [super reloadRootControllersWithNames:names contexts:contexts];
 }
 
 @end

--- a/WatchKit/WatchKit/WKInterfaceDevice.h
+++ b/WatchKit/WatchKit/WKInterfaceDevice.h
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import "PCKMessageCapturer.h"
+
+@class UIImage;
+
+@interface WKInterfaceDevice : PCKMessageCapturer;
+
++ (WKInterfaceDevice *)currentDevice;
+
+- (BOOL)addCachedImage:(UIImage *)image name:(NSString *)name;
+- (BOOL)addCachedImageWithData:(NSData *)imageData name:(NSString *)name;
+- (void)removeCachedImageWithName:(NSString *)name;
+- (void)removeAllCachedImages;
+
+@property(nonatomic,readonly) CGRect screenBounds;
+@property(nonatomic,readonly) CGFloat screenScale;
+@property(nonatomic,readonly,copy) NSString *preferredContentSizeCategory;
+@property(nonatomic,readonly,strong) NSDictionary *cachedImages;
+
+@end

--- a/WatchKit/WatchKit/WKInterfaceDevice.m
+++ b/WatchKit/WatchKit/WKInterfaceDevice.m
@@ -1,0 +1,51 @@
+#import "WKInterfaceDevice.h"
+
+@interface PCKMessageCapturer ()
+
++ (WKInterfaceDevice *)currentDevice NS_REQUIRES_SUPER;
+
+- (BOOL)addCachedImage:(UIImage *)image name:(NSString *)name NS_REQUIRES_SUPER;
+- (BOOL)addCachedImageWithData:(NSData *)imageData name:(NSString *)name NS_REQUIRES_SUPER;
+- (void)removeCachedImageWithName:(NSString *)name NS_REQUIRES_SUPER;
+- (void)removeAllCachedImages NS_REQUIRES_SUPER;
+
+@end
+
+@interface WKInterfaceDevice ()
+
+@property(nonatomic) CGRect screenBounds;
+@property(nonatomic) CGFloat screenScale;
+@property(nonatomic, copy) NSString *preferredContentSizeCategory;
+@property(nonatomic, strong) NSDictionary *cachedImages;
+
+@end
+
+@implementation WKInterfaceDevice
+
++ (WKInterfaceDevice *)currentDevice
+{
+    [super currentDevice];
+    return [[WKInterfaceDevice alloc] init];
+}
+
+- (BOOL)addCachedImage:(UIImage *)image name:(NSString *)name
+{
+    return [super addCachedImage:image name:name];
+}
+
+- (BOOL)addCachedImageWithData:(NSData *)imageData name:(NSString *)name
+{
+    return [super addCachedImageWithData:imageData name:name];
+}
+
+- (void)removeCachedImageWithName:(NSString *)name
+{
+    [super removeCachedImageWithName:name];
+}
+
+- (void)removeAllCachedImages
+{
+    [super removeAllCachedImages];
+}
+
+@end

--- a/WatchKit/WatchKit/WatchKit.h
+++ b/WatchKit/WatchKit/WatchKit.h
@@ -5,6 +5,7 @@
 #import "WKInterfaceSeparator.h"
 #import "WKInterfaceButton.h"
 #import "WKInterfaceDate.h"
+#import "WKInterfaceDevice.h"
 #import "WKInterfaceSwitch.h"
 #import "WKInterfaceTable.h"
 #import "WKInterfaceSlider.h"


### PR DESCRIPTION
So our project was using the `openParentApplication:reply:` selector and we had to fork it to allow our specs to compile.  I sat down and tried to figure our how to test these class methods without adding support for class stubs in Cedar.  I spoke with Sam Coward about this briefly and without doing some more gnarly implementation of a custom Cedar matcher or NSInvocation category, this is what I came up with.  The tests pass for `openParentApplication:reply:` and `reloadRootControllersWithNames:contexts:`

My primary motivation for submitting this is not wanting to be on a custom fork of PCK for our Watch project.  Obviously making it available for others is important as well, but I didn't want us to miss out on future PCK updates.