### PR TITLE
Backfill tests #137

### DIFF
--- a/Foundation/Spec/Fakes/PSHKFakeOperationQueueSpec.mm
+++ b/Foundation/Spec/Fakes/PSHKFakeOperationQueueSpec.mm
@@ -146,6 +146,25 @@ describe(@"PSHKFakeOperationQueue", ^{
             });
         });
     });
+
+    describe(@"-cancelAllOperations", ^{
+        __block NSOperation *operation;
+
+        beforeEach(^{
+            operation = [[[NSOperation alloc] init] autorelease];
+            [fakeQueue addOperation:operation];
+
+            [fakeQueue cancelAllOperations];
+        });
+
+        it(@"should cancel each operation", ^{
+            operation.cancelled should be_truthy;
+        });
+
+        it(@"should no longer have any queued operations", ^{
+            fakeQueue.operationCount should equal(0);
+        });
+    });
 });
 
 SPEC_END

--- a/Foundation/Spec/Fakes/PSHKFakeOperationQueueSpec.mm
+++ b/Foundation/Spec/Fakes/PSHKFakeOperationQueueSpec.mm
@@ -45,25 +45,38 @@ describe(@"PSHKFakeOperationQueue", ^{
     });
 
     describe(@"when set to run synchronously", ^{
+        __block BOOL blockInvoked;
+        __block dispatch_semaphore_t semaphore;
+        __block NSBlockOperation *blockOperation;
+
         beforeEach(^{
             fakeQueue.runSynchronously = YES;
-        });
 
-        it(@"should run operations immediately when added", ^{
-            dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-            __block BOOL blockInvoked = NO;
+            semaphore = dispatch_semaphore_create(0);
+            blockInvoked = NO;
 
-            NSBlockOperation *blockOperation = [NSBlockOperation blockOperationWithBlock:^{
+            blockOperation = [NSBlockOperation blockOperationWithBlock:^{
                 blockInvoked = YES;
                 dispatch_semaphore_signal(semaphore);
             }];
+        });
 
+        afterEach(^{
+            dispatch_release(semaphore);
+        });
+
+        it(@"should run an operation immediately when added", ^{
             [fakeQueue addOperation:blockOperation];
             dispatch_semaphore_wait(semaphore, 0.0001);
 
             blockInvoked should be_truthy;
+        });
 
-            dispatch_release(semaphore);
+        it(@"should run all operations immediately when several are added", ^{
+            [fakeQueue addOperations:@[blockOperation] waitUntilFinished:NO];
+            dispatch_semaphore_wait(semaphore, 0.0001);
+
+            blockInvoked should be_truthy;
         });
     });
 

--- a/Foundation/SpecHelper/Fakes/PSHKFakeOperationQueue.m
+++ b/Foundation/SpecHelper/Fakes/PSHKFakeOperationQueue.m
@@ -81,9 +81,11 @@
 }
 
 - (void)cancelAllOperations {
-    for (NSOperation *op in self.operations) {
+    for (NSOperation *op in self.mutableOperations) {
         [op cancel];
     }
+
+    [self.mutableOperations removeAllObjects];
 }
 
 @end

--- a/Foundation/SpecHelper/Fakes/PSHKFakeOperationQueue.m
+++ b/Foundation/SpecHelper/Fakes/PSHKFakeOperationQueue.m
@@ -37,16 +37,10 @@
             operation = [NSBlockOperation blockOperationWithBlock:[[operation copy] autorelease]];
         }
         
-        if (wait) {
+        if (wait || self.runSynchronously) {
             [self performOperationAndWait:operation];
         } else {
             [self.mutableOperations addObject:operation];
-        }
-    }
-    
-    if (self.runSynchronously) {
-        for (NSOperation *operation in self.operations) {
-            [self performOperationAndWait:operation];
         }
     }
 }

--- a/Foundation/SpecHelper/Fakes/PSHKFakeOperationQueue.m
+++ b/Foundation/SpecHelper/Fakes/PSHKFakeOperationQueue.m
@@ -36,11 +36,17 @@
         if (![operation isKindOfClass:[NSOperation class]]) {
             operation = [NSBlockOperation blockOperationWithBlock:[[operation copy] autorelease]];
         }
-
+        
         if (wait) {
             [self performOperationAndWait:operation];
         } else {
             [self.mutableOperations addObject:operation];
+        }
+    }
+    
+    if (self.runSynchronously) {
+        for (NSOperation *operation in self.operations) {
+            [self performOperationAndWait:operation];
         }
     }
 }
@@ -78,6 +84,12 @@
         ((void (^)())operation)();
     }
     [self.mutableOperations removeObject:operation];
+}
+
+- (void)cancelAllOperations {
+    for (NSOperation *op in self.operations) {
+        [op cancel];
+    }
 }
 
 @end


### PR DESCRIPTION
I thought that @codeman9 had a good point in issuing pull request #137 -- it's important that our fakes behave as closely to the real thing as possible. Given only a subset of relevant methods for NSOperationQueue were implemented on the fake, it's all too easy to fall into the trap of assuming all of the relevant methods you can call on a real one would work on the fake as well. The end result of this (in my experience) is hard to debug tests and unhappy developers.

To that end, I backfilled tests for the proposed changes to `-addOperations:waitUntilFinished:` and `-cancelAllOperations`.