### PR TITLE
Saves off the cameraDevice that is set for a UIImagePickerController.

### DIFF
--- a/UIKit/SpecHelper/Stubs/UIImagePickerController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIImagePickerController+Spec.m
@@ -1,6 +1,8 @@
 #import "UIImagePickerController+Spec.h"
+#import <objc/runtime.h>
 
 static BOOL isCameraAvailable__, isPhotoLibraryAvailable__, isSavedPhotosAlbumAvailable__;
+static const NSNumber *cameraDevice__;
 
 @implementation UIImagePickerController (Spec)
 
@@ -18,6 +20,16 @@ static BOOL isCameraAvailable__, isPhotoLibraryAvailable__, isSavedPhotosAlbumAv
 
 + (void)setSavedPhotosAlbumAvailable:(BOOL)available {
     isSavedPhotosAlbumAvailable__ = available;
+}
+
+- (void)setCameraDevice:(UIImagePickerControllerCameraDevice)cameraDevice
+{
+    objc_setAssociatedObject(self, &cameraDevice__, [NSNumber numberWithInteger:cameraDevice],  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (UIImagePickerControllerCameraDevice)cameraDevice
+{
+    return (UIImagePickerControllerCameraDevice)[objc_getAssociatedObject(self, &cameraDevice__) integerValue];
 }
 
 #pragma mark - Overrides


### PR DESCRIPTION
It looks like the simulator implementation of UIImagePickerController just
drops the camera device value on the floor. This change saves the value off
into an associated object so that assertions can be made about what camera
device is set.