### PR TITLE
Use +load instead of +initialize for UINavigationController stubbing.

### DIFF
--- a/UIKit/SpecHelper/Stubs/UINavigationController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UINavigationController+Spec.m
@@ -20,7 +20,7 @@
 
 @implementation UINavigationControllerStubbing
 
-+ (void)initialize {
++ (void)load {
     [PCKMethodRedirector redirectSelector:@selector(pushViewController:animated:)
                                  forClass:[UINavigationController class]
                                        to:@selector(pushViewController:ignoringAnimated:)


### PR DESCRIPTION
+initialize only triggers with someone calls a method on the `UINavigationControllerStubbing` class. +load is called at launch.

PCK specs incidentally calls +initialize thanks to CDRSelectClasses(). Actual code ends up not swizzling these methods.