### PR TITLE
Update CHANGES.markdown

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -3,7 +3,10 @@
 ## 0.3.1 (in progress)
  
   * Further improvements to UIGestureRecognizer spec helper stub
-  * 
+  * Improvements to PCK's fake operation queue.
+  * Adds support for inspecting the urls opened with UIApplication
+  * Adds support for inspecting the `-cameraDevice` set on a UIImagePickerController
+  * UINavigationController stubs are now properly loaded.
 
 ## 0.3.0
 


### PR DESCRIPTION
Update CHANGES.markdown for changes since 0.3.0.
Should we cut 0.3.1? Seems like we have enough miscellanea here.