### PR TITLE
Add [UIView pauseAnimations] and supporting methods

### DIFF
--- a/UIKit/Spec/Stubs/UIViewSpec+StubbedAnimations.mm
+++ b/UIKit/Spec/Stubs/UIViewSpec+StubbedAnimations.mm
@@ -15,111 +15,172 @@ describe(@"UIView+StubbedAnimation", ^{
         completionBlockCalled = NO;
     });
 
-    describe(@"+animateWithDuration:animations:", ^{
+    describe(@"with animations not paused", ^{
+        describe(@"+animateWithDuration:animations:", ^{
+            beforeEach(^{
+                [UIView animateWithDuration:0.666 animations:^{
+                    animationBlockCalled = YES;
+                }];
+            });
+
+            it(@"should call the animation block", ^{
+                animationBlockCalled should be_truthy;
+            });
+
+            it(@"should remember the duration", ^{
+                [UIView lastAnimationDuration] should be_close_to(.666);
+            });
+        });
+
+        describe(@"+animateWithDuration:animations:completion:", ^{
+            beforeEach(^{
+                [UIView animateWithDuration:0.666 animations:^{
+                    animationBlockCalled = YES;
+                } completion:^(BOOL finished) {
+                    completionBlockCalled = YES;
+                }];
+            });
+
+            it(@"should call the animation block", ^{
+                animationBlockCalled should be_truthy;
+            });
+
+            it(@"should call the completion block", ^{
+                completionBlockCalled should be_truthy;
+            });
+
+            it(@"should remember the duration", ^{
+                [UIView lastAnimationDuration] should be_close_to(.666);
+            });
+        });
+
+        describe(@"+animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:", ^{
+            beforeEach(^{
+                [UIView animateWithDuration:0.666 delay:10 usingSpringWithDamping:176 initialSpringVelocity:117 options:UIViewAnimationOptionTransitionCrossDissolve animations:^{
+                    animationBlockCalled = YES;
+                } completion:^(BOOL finished) {
+                    completionBlockCalled = YES;
+                }];
+            });
+
+            it(@"should call the animation block", ^{
+                animationBlockCalled should be_truthy;
+            });
+
+            it(@"should call the completion block", ^{
+                completionBlockCalled should be_truthy;
+            });
+
+            it(@"should remember the damping ratio", ^{
+                [UIView lastAnimationSpringWithDamping] should be_close_to(176);
+            });
+
+            it(@"should remember the initial spring velocity", ^{
+                [UIView lastAnimationInitialSpringVelocity] should be_close_to(117);
+            });
+
+            it(@"should remember the duration", ^{
+                [UIView lastAnimationDuration] should be_close_to(.666);
+            });
+
+            it(@"should remember the delay", ^{
+                [UIView lastAnimationDelay] should be_close_to(10);
+            });
+
+            it(@"should remember the options", ^{
+                [UIView lastAnimationOptions] should equal(UIViewAnimationOptionTransitionCrossDissolve);
+            });
+        });
+
+        describe(@"+animateWithDuration:delay:options:animations:completion:", ^{
+            beforeEach(^{
+                [UIView animateWithDuration:0.666 delay:10
+                                    options:UIViewAnimationOptionTransitionFlipFromBottom
+                                 animations:^{
+                                     animationBlockCalled = YES;
+                                 } completion:^(BOOL finished) {
+                                     completionBlockCalled = YES;
+                                 }];
+            });
+
+            it(@"should remember the duration", ^{
+                [UIView lastAnimationDuration] should be_close_to(.666);
+            });
+
+            it(@"should remember the delay", ^{
+                [UIView lastAnimationDelay] should be_close_to(10);
+            });
+
+            it(@"should remember the options", ^{
+                [UIView lastAnimationOptions] should equal(UIViewAnimationOptionTransitionFlipFromBottom);
+            });
+
+            it(@"should call the animation block", ^{
+                animationBlockCalled should be_truthy;
+            });
+
+            it(@"should call the completion block", ^{
+                completionBlockCalled should be_truthy;
+            });
+        });
+    });
+
+    describe(@"with animations paused", ^{
+        __block BOOL completionBlockParameter;
+
         beforeEach(^{
+            [UIView pauseAnimations];
             [UIView animateWithDuration:0.666 animations:^{
                 animationBlockCalled = YES;
-            }];
-        });
-
-        it(@"should call the animation block", ^{
-            animationBlockCalled should be_truthy;
-        });
-
-        it(@"should remember the duration", ^{
-            [UIView lastAnimationDuration] should be_close_to(.666);
-        });
-    });
-
-    describe(@"+animateWithDuration:animations:completion:", ^{
-        beforeEach(^{
-            [UIView animateWithDuration:0.666 animations:^{
-                animationBlockCalled = YES;
             } completion:^(BOOL finished) {
                 completionBlockCalled = YES;
+                completionBlockParameter = finished;
             }];
         });
 
-        it(@"should call the animation block", ^{
-            animationBlockCalled should be_truthy;
+        it(@"should not execute the the animation block", ^{
+            animationBlockCalled should be_falsy;
         });
 
-        it(@"should call the completion block", ^{
-            completionBlockCalled should be_truthy;
+        it(@"should not execute the completion block", ^{
+            completionBlockCalled should be_falsy;
         });
 
-        it(@"should remember the duration", ^{
-            [UIView lastAnimationDuration] should be_close_to(.666);
-        });
-    });
-
-    describe(@"+animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:", ^{
-        beforeEach(^{
-            [UIView animateWithDuration:0.666 delay:10 usingSpringWithDamping:176 initialSpringVelocity:117 options:UIViewAnimationOptionTransitionCrossDissolve animations:^{
-                animationBlockCalled = YES;
-            } completion:^(BOOL finished) {
-                completionBlockCalled = YES;
-            }];
+        it(@"should records the animation", ^{
+            [[UIView lastAnimation] duration] should equal(0.666);
         });
 
-        it(@"should call the animation block", ^{
-            animationBlockCalled should be_truthy;
+        describe(@"running animations", ^{
+            beforeEach(^{
+                [[UIView lastAnimation] animate];
+            });
+
+            it(@"should run the animation block", ^{
+                animationBlockCalled should be_truthy;
+            });
         });
 
-        it(@"should call the completion block", ^{
-            completionBlockCalled should be_truthy;
+        describe(@"completing", ^{
+            beforeEach(^{
+                [[UIView lastAnimation] animate];
+                [[UIView lastAnimation] complete];
+            });
+
+            it(@"should run the completion block with YES", ^{
+                completionBlockCalled should be_truthy;
+                completionBlockParameter should be_truthy;
+            });
         });
 
-        it(@"should remember the damping ratio", ^{
-            [UIView lastAnimationSpringWithDamping] should be_close_to(176);
-        });
+        describe(@"cancelling", ^{
+            beforeEach(^{
+                [[UIView lastAnimation] cancel];
+            });
 
-        it(@"should remember the initial spring velocity", ^{
-            [UIView lastAnimationInitialSpringVelocity] should be_close_to(117);
-        });
-
-        it(@"should remember the duration", ^{
-            [UIView lastAnimationDuration] should be_close_to(.666);
-        });
-
-        it(@"should remember the delay", ^{
-            [UIView lastAnimationDelay] should be_close_to(10);
-        });
-
-        it(@"should remember the options", ^{
-            [UIView lastAnimationOptions] should equal(UIViewAnimationOptionTransitionCrossDissolve);
-        });
-    });
-
-    describe(@"+animateWithDuration:delay:options:animations:completion:", ^{
-        beforeEach(^{
-            [UIView animateWithDuration:0.666 delay:10
-                                options:UIViewAnimationOptionTransitionFlipFromBottom
-                             animations:^{
-                animationBlockCalled = YES;
-            } completion:^(BOOL finished) {
-                completionBlockCalled = YES;
-            }];
-        });
-
-        it(@"should remember the duration", ^{
-            [UIView lastAnimationDuration] should be_close_to(.666);
-        });
-
-        it(@"should remember the delay", ^{
-            [UIView lastAnimationDelay] should be_close_to(10);
-        });
-
-        it(@"should remember the options", ^{
-            [UIView lastAnimationOptions] should equal(UIViewAnimationOptionTransitionFlipFromBottom);
-        });
-
-        it(@"should call the animation block", ^{
-            animationBlockCalled should be_truthy;
-        });
-
-        it(@"should call the completion block", ^{
-            completionBlockCalled should be_truthy;
+            it(@"should call the completion block with NO", ^{
+                completionBlockCalled should be_truthy;
+                completionBlockParameter should be_falsy;
+            });
         });
     });
 });

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.h
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.h
@@ -1,5 +1,21 @@
 #import <UIKit/UIKit.h>
 
+@interface PCKViewAnimation : NSObject
+
+@property (assign, nonatomic) NSTimeInterval duration;
+@property (assign, nonatomic) NSTimeInterval delay;
+@property (assign, nonatomic) CGFloat springWithDamping;
+@property (assign, nonatomic) CGFloat initialSpringVelocity;
+@property (assign, nonatomic) UIViewAnimationOptions options;
+@property (strong, nonatomic) void (^animationBlock)(void);
+@property (strong, nonatomic) void (^completionBlock)(BOOL);
+
+- (void)animate;
+- (void)complete;
+- (void)cancel;
+
+@end
+
 @interface UIView (StubbedAnimation)
 
 + (NSTimeInterval)lastAnimationDuration;
@@ -7,5 +23,9 @@
 + (UIViewAnimationOptions)lastAnimationOptions;
 + (CGFloat)lastAnimationSpringWithDamping;
 + (CGFloat)lastAnimationInitialSpringVelocity;
+
++ (void)pauseAnimations;
++ (NSArray *)animations;
++ (PCKViewAnimation *)lastAnimation;
 
 @end


### PR DESCRIPTION
This adds some functionality to `UIView (StubbedAnimations)` to allow testing intermediate states of animations.  We needed this to get good test coverage of some complicated view controller transition animations in our project.

This adds `[UIView pauseAnimations]`, which if invoked in a test, will cause animations and completion blocks not to be immediately called.  These blocks can be called later via `[UIView animations]` and `PCKViewAnimation` instances which have also been added.  Options for the animation can also be inspected via these objects, regardless of whether animations were paused or not.  (This is similar to `NSURLConnection (Spec) -connections`.)

Animation pausing is cleared and disabled in the `beforeEach`, so this should not affect existing tests.

@tjarratt @akitchen @avh4 If you can take a look and give feedback so we can get this merged before Friday, that would be great.