### PR TITLE
Adds ability to toggle UIViewController spec stubs

### DIFF
--- a/UIKit/SpecHelper/Stubs/UIViewController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIViewController+Spec.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface UIViewController (Spec)
+
++ (void)pck_useSpecStubs:(BOOL)useSpecStubs;
+
+@end

--- a/UIKit/SpecHelper/Stubs/UIViewController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIViewController+Spec.m
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+#import "UIViewController+Spec.h"
 #import <objc/runtime.h>
 
 #pragma clang diagnostic push
@@ -8,11 +8,56 @@
 static char PRESENTING_CONTROLLER_KEY;
 static char PRESENTED_CONTROLLER_KEY;
 
+
 @implementation UIViewController (Spec)
+
++ (void)load {
+    [self pck_useSpecStubs:YES];
+}
+
++ (void)pck_useSpecStubs:(BOOL)useSpecStubs {
+    unsigned int outCount;
+    Method *methods = class_copyMethodList(self, &outCount);
+    for (int i = 0; i < outCount; ++i) {
+        Method method = methods[i];
+        SEL pckSelector = method_getName(method);
+        NSString *pckSelectorName = NSStringFromSelector(pckSelector);
+
+        if ([pckSelectorName hasPrefix:@"pck_"]) {
+            Method pckMethod = class_getInstanceMethod(self, pckSelector);
+            IMP pckImplementation = method_getImplementation(pckMethod);
+
+            NSString *originalSelectorName = [pckSelectorName substringFromIndex:@"pck_".length];
+            SEL originalSelector = NSSelectorFromString(originalSelectorName);
+
+            Method currentMethod = class_getInstanceMethod(self, originalSelector);
+            if (currentMethod == NULL) { continue; }
+
+            NSString *preservedSelectorName = [@"_pck_preserved_" stringByAppendingString:originalSelectorName];
+            SEL preservedSelector = NSSelectorFromString(preservedSelectorName);
+
+            if (useSpecStubs) {
+                // class_addMethod is used here since it only adds the method if it doesn't already exist, and is a
+                // no-op otherwise. This prevents us from accidentally overwriting the preserved original IMP with a
+                // pck stub
+                class_addMethod(self, preservedSelector, method_getImplementation(currentMethod), method_getTypeEncoding(currentMethod));
+                method_setImplementation(currentMethod, pckImplementation);
+            }
+            else {
+                Method preservedMethod = class_getInstanceMethod(self, preservedSelector);
+                if (preservedMethod == NULL) { continue; }
+
+                IMP preservedImplementation = method_getImplementation(preservedMethod);
+                method_setImplementation(currentMethod, preservedImplementation);
+            }
+        }
+    }
+    free(methods);
+}
 
 #pragma mark - Modals
 
-- (void)presentViewController:(UIViewController *)modalViewController animated:(BOOL)animated completion:(void(^)(void))onComplete {
+- (void)pck_presentViewController:(UIViewController *)modalViewController animated:(BOOL)animated completion:(void(^)(void))onComplete {
     if (!modalViewController) {
         NSString *errorReason = [NSString stringWithFormat:@"Application tried to present a nil modal view controller on target %@", self];
         [[NSException exceptionWithName:NSInvalidArgumentException reason:errorReason userInfo:nil] raise];
@@ -22,17 +67,17 @@ static char PRESENTED_CONTROLLER_KEY;
         [[NSException exceptionWithName:NSInternalInconsistencyException reason:errorReason userInfo:nil] raise];
     }
 
-    self.presentedViewController = modalViewController;
-    modalViewController.presentingViewController = self;
+    [self _pck_setPresentedViewController:modalViewController];
+    [modalViewController _pck_setPresentingViewController:self];
     if (onComplete) {
         onComplete();
     }
 }
 
-- (void)dismissViewControllerAnimated:(BOOL)animated completion:(void (^)(void))completion {
+- (void)pck_dismissViewControllerAnimated:(BOOL)animated completion:(void (^)(void))completion {
     if (self.presentedViewController) {
-        self.presentedViewController.presentingViewController = nil;
-        self.presentedViewController = nil;
+        [self.presentedViewController _pck_setPresentingViewController:nil];
+        [self _pck_setPresentedViewController:nil];
     } else if (self.presentingViewController) {
         [self.presentingViewController dismissModalViewControllerAnimated:YES];
     } else if (self.navigationController) {
@@ -46,43 +91,43 @@ static char PRESENTED_CONTROLLER_KEY;
 
 #pragma mark Deprecated Modal APIs
 
-- (void)presentModalViewController:(UIViewController *)modalViewController animated:(BOOL)animated {
+- (void)pck_presentModalViewController:(UIViewController *)modalViewController animated:(BOOL)animated {
     [self presentViewController:modalViewController animated:animated completion:nil];
 }
 
-- (void)dismissModalViewControllerAnimated:(BOOL)animated {
+- (void)pck_dismissModalViewControllerAnimated:(BOOL)animated {
     [self dismissViewControllerAnimated:animated completion:nil];
 }
 
-- (UIViewController *)modalViewController {
+- (UIViewController *)pck_modalViewController {
     return self.presentedViewController;
 }
 
 #pragma mark Modal Properties
 
-- (void)setPresentedViewController:(UIViewController *)modalViewController {
+- (void)_pck_setPresentedViewController:(UIViewController *)modalViewController {
     objc_setAssociatedObject(self, &PRESENTED_CONTROLLER_KEY, modalViewController, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (UIViewController *)presentedViewController {
+- (UIViewController *)pck_presentedViewController {
     return objc_getAssociatedObject(self, &PRESENTED_CONTROLLER_KEY);
 }
 
-- (void)setPresentingViewController:(UIViewController *)presentingViewController {
+- (void)_pck_setPresentingViewController:(UIViewController *)presentingViewController {
     objc_setAssociatedObject(self, &PRESENTING_CONTROLLER_KEY, presentingViewController, OBJC_ASSOCIATION_ASSIGN);
 }
 
-- (UIViewController *)presentingViewController {
+- (UIViewController *)pck_presentingViewController {
     return objc_getAssociatedObject(self, &PRESENTING_CONTROLLER_KEY);
 }
 
 #pragma mark - Animation
-- (void)animateWithDuration:(NSTimeInterval)duration animations:(void (^)(void))animations completion:(void (^)(BOOL finished))completion {
+- (void)pck_animateWithDuration:(NSTimeInterval)duration animations:(void (^)(void))animations completion:(void (^)(BOOL finished))completion {
     animations();
     completion(YES);
 }
 
-- (void)transitionFromViewController:(UIViewController *)fromViewController toViewController:(UIViewController *)toViewController duration:(NSTimeInterval)duration options:(UIViewAnimationOptions)options animations:(void (^)(void))animations completion:(void (^)(BOOL))completion {
+- (void)pck_transitionFromViewController:(UIViewController *)fromViewController toViewController:(UIViewController *)toViewController duration:(NSTimeInterval)duration options:(UIViewAnimationOptions)options animations:(void (^)(void))animations completion:(void (^)(BOOL))completion {
     animations();
     completion(YES);
 }

--- a/UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h
+++ b/UIKit/SpecHelper/UIKit+PivotalSpecHelperStubs.h
@@ -5,3 +5,4 @@
 #import "UIGestureRecognizer+Spec.h"
 #import "UIAlertAction+Spec.h"
 #import "UIAlertController+Spec.h"
+#import "UIViewController+Spec.h"

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		AE03FC941B0A89BA00013784 /* UITabBarController+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE86BD41179C7C910057DEAE /* UITabBarController+Spec.m */; };
 		AE03FC951B0A89C100013784 /* UITabBarController+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE86BD40179C7C910057DEAE /* UITabBarController+Spec.h */; };
 		AE03FC9A1B0A8AC500013784 /* UISwitch+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = FAF932CB192703280076C733 /* UISwitch+Spec.h */; };
+		AE04B1E71B50821B00248694 /* UIViewController+Spec.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = DE99C6A16495A2EF63F66D48 /* UIViewController+Spec.h */; };
 		AE062BD01A43240500AF8D33 /* UIAlertActionSpec+Spec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE062BCE1A4323CF00AF8D33 /* UIAlertActionSpec+Spec.mm */; };
 		AE118AA418D6B57000C90D6B /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE118AA318D6B57000C90D6B /* SenTestingKit.framework */; };
 		AE118AA718D6B57000C90D6B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AEBCCBE7168B97DD0056EE83 /* Foundation.framework */; };
@@ -332,6 +333,7 @@
 			dstPath = "${BUILD_DIR}/${CONFIGURATION}-iphoneuniversal/${PRODUCT_NAME}.framework/Headers";
 			dstSubfolderSpec = 0;
 			files = (
+				AE04B1E71B50821B00248694 /* UIViewController+Spec.h in Copy headers to framework */,
 				AEC40CC9174C292600474D2D /* UIActionSheet+Spec.h in Copy headers to framework */,
 				AEC40CCA174C292600474D2D /* UIAlertView+Spec.h in Copy headers to framework */,
 				AEE0B69618A3572C0007A9D0 /* UIView+StubbedAnimation.h in Copy headers to framework */,
@@ -510,6 +512,7 @@
 		B8C62E6E16BC04230009CDAD /* UIBarButtonItemSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UIBarButtonItemSpec+Spec.mm"; sourceTree = "<group>"; };
 		B8C62E7016BC04940009CDAD /* Target.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Target.h; sourceTree = "<group>"; };
 		B8C62E7116BC04940009CDAD /* Target.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Target.m; sourceTree = "<group>"; };
+		DE99C6A16495A2EF63F66D48 /* UIViewController+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Spec.h"; sourceTree = "<group>"; };
 		DE99C78703C6C6CA8C0465B3 /* UIGestureRecognizer+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIGestureRecognizer+Spec.h"; sourceTree = "<group>"; };
 		DE99CB8E2255BDC5D711130D /* UIGestureRecognizer+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIGestureRecognizer+Spec.m"; sourceTree = "<group>"; };
 		FA07586618120BB1001817BF /* UICollectionViewCellSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UICollectionViewCellSpec+Spec.mm"; sourceTree = "<group>"; };
@@ -847,6 +850,7 @@
 				AE89900218071F3A00DDB948 /* UIView+StubbedAnimation.m */,
 				AECB46AA1A3FBA9E00398720 /* UIView+StubbedGestureRecognizers.h */,
 				AECB46AB1A3FBA9E00398720 /* UIView+StubbedGestureRecognizers.m */,
+				DE99C6A16495A2EF63F66D48 /* UIViewController+Spec.h */,
 				AEC40CB2174C22BD00474D2D /* UIViewController+Spec.m */,
 				AEC40CB3174C22BD00474D2D /* UIWebView+Spec.h */,
 				AEC40CB4174C22BD00474D2D /* UIWebView+Spec.m */,


### PR DESCRIPTION
- `[UIViewController +pck_useSpecStubs:]` will swap instance methods with
  the signature `pck_methodToStub` with the original method
  `methodToStub` if the original method exists. For example:

  `pck_viewWillAppear:` will replace `viewWillAppear:` but `pck_yolo`
  will be ignored.
- This also makes the stub installation (at least for UIViewController)
  much safer. See [apple’s docs](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html#//apple_ref/doc/uid/TP40011210-CH6-SW4) for more info.
- It also allows stubs to be removed in the case someone wants to test the real behavior.
  