### PR TITLE
Adds `-rootInterfaceControllerForStoryboardNamed:inBundle:`

### DIFF
--- a/WatchKit/Specs/Fixtures/Rootless.storyboard
+++ b/WatchKit/Specs/Fixtures/Rootless.storyboard
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="7701"/>
+    </dependencies>
+    <scenes>
+        <!--Interface Controller-->
+        <scene sceneID="r6y-rf-gUe">
+            <objects>
+                <controller id="bIx-9o-ACs"/>
+            </objects>
+            <point key="canvasLocation" x="661" y="233"/>
+        </scene>
+    </scenes>
+</document>

--- a/WatchKit/Specs/WatchKit/PCKInterfaceControllerLoaderSpec.mm
+++ b/WatchKit/Specs/WatchKit/PCKInterfaceControllerLoaderSpec.mm
@@ -3,6 +3,7 @@
 #import "NotificationController.h"
 #import "GlanceController.h"
 #import "CustomCategoryNotificationController.h"
+#import "PCKInterfaceControllerLoader.h"
 
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
@@ -19,6 +20,280 @@ describe(@"PCKInterfaceControllerLoader", ^{
         subject = [[PCKInterfaceControllerLoader alloc] init];
     });
 
+    describe(@"providing an instance of the root WKInterfaceController that lives in a storyboard", ^{
+        context(@"when there is no storyboard matching the name", ^{
+            it(@"should raise an exception with a helpful message", ^{
+                ^{
+                    [subject rootInterfaceControllerForStoryboardNamed:@"NonExistentName"
+                                                              inBundle:testBundle];
+                }
+                should raise_exception
+                    .with_name(NSInvalidArgumentException)
+                    .with_reason(@"No storyboard named 'NonExistentName' exists in the test target.  Did you forget to add it?");
+            });
+        });
+
+        context(@"when there is no initial controller in the storyboard matching the name", ^{
+            it(@"should raise an exception with a helpful message", ^{
+                NSException *theException;
+                @try {
+                    [subject rootInterfaceControllerForStoryboardNamed:@"Rootless"
+                                                              inBundle:testBundle];
+                }
+                @catch (NSException *exception) {
+                    theException = exception;
+                }
+                @finally {
+                    theException.name should equal(NSInvalidArgumentException);
+                    theException.reason should equal(@"No root controller found for storyboard named 'Rootless'.  Did you forget to set it in interface builder?");
+                }
+            });
+        });
+
+        xdescribe(@"This cannot be tested until Xcode supports having multiple Watchkit storyboards", ^{
+            // See: http://www.openradar.appspot.com/19781408
+            context(@"when there is an interface controller instance in an existing storyboard but its class doesn't exist in the current target", ^{
+                it(@"should raise an exception with a helpful message", ^{
+                    NSException *theException;
+                    @try {
+                        [subject rootInterfaceControllerForStoryboardNamed:@"StoryboardWithInvalidRootController"
+                                                                  inBundle:testBundle];
+                    }
+                    @catch (NSException *exception) {
+                        theException = exception;
+                    }
+                    @finally {
+                        theException.name should equal(NSInvalidArgumentException);
+                        theException.reason should equal(@"No class named 'NonExistentController' exists in the current target.  Did you forget to add it to the test target?");
+                    }
+                });
+            });
+
+            context(@"when there root interface  controller has objects associated with it that do not have a corresponding outlet", ^{
+                it(@"should not throw a runtime exception, because it doesn't throw one in production", ^{
+                    ^{
+                        [subject rootInterfaceControllerForStoryboardNamed:@"StoryboardWithRootControllerWithInvalidAssociatedObjects"
+                                                                  inBundle:testBundle]; }
+                    should_not raise_exception;
+                });
+            });
+        });
+
+        context(@"when there is a root interface controller", ^{
+            __block InterfaceController *controller;
+
+            beforeEach(^{
+                controller = [subject rootInterfaceControllerForStoryboardNamed:@"Interface"
+                                                                       inBundle:testBundle];
+            });
+
+            it(@"should return the correct type of interface controller", ^{
+                controller should be_instance_of([InterfaceController class]);
+            });
+
+            describe(@"the interface controller's properties", ^{
+                describe(@"the title label", ^{
+                    __block WKInterfaceLabel *titleLabel;
+                    beforeEach(^{
+                        titleLabel = controller.titleLabel;
+                    });
+
+                    it(@"should have the correct text", ^{
+                        titleLabel.text should equal(@"Some text");
+                    });
+
+                    it(@"should have the correct text color", ^{
+                        titleLabel.textColor should equal([UIColor colorWithRed:255.0f / 255.0f
+                                                                          green:125.0f / 255.0f
+                                                                           blue:55.0f / 255.0f
+                                                                          alpha:1.0]);
+                    });
+                });
+
+                describe(@"the button", ^{
+                    __block WKInterfaceButton *button;
+                    beforeEach(^{
+                        button = controller.actionButton;
+                    });
+
+                    it(@"should have the correct text", ^{
+                        button.title should equal(@"actionButton");
+                    });
+
+                    it(@"should have the correct text color", ^{
+                        button.color should equal([UIColor lightGrayColor]);
+                    });
+
+                    it(@"should have the correct default enabled property", ^{
+                        button.enabled should be_truthy;
+                    });
+
+                    it(@"should allow the enabled property to be toggled programatically", ^{
+                        [controller didDeactivate];
+                        button.enabled should_not be_truthy;
+                    });
+                });
+
+                describe(@"the date", ^{
+                    __block WKInterfaceDate *date;
+                    beforeEach(^{
+                        date = controller.date;
+                    });
+
+                    it(@"should display date in the correct format", ^{
+                        date.format should equal(@"yy-M-d");
+                    });
+
+                    it(@"should display the correct color", ^{
+                        date.textColor should equal([UIColor lightGrayColor]);
+                    });
+                });
+
+                describe(@"the switch", ^{
+                    __block WKInterfaceSwitch *theSwitch;
+                    beforeEach(^{
+                        theSwitch = controller.theSwitch;
+                    });
+
+                    it(@"should have the correct default enabled property", ^{
+                        theSwitch.enabled should be_truthy;
+                    });
+
+                    it(@"should allow the enabled property to be toggled programatically", ^{
+                        [controller didDeactivate];
+                        theSwitch.enabled should_not be_truthy;
+                    });
+
+                    it(@"should have the correct default on property", ^{
+                        theSwitch.on should be_truthy;
+                    });
+
+                    it(@"should allow the on property to be toggled programatically", ^{
+                        [controller didDeactivate];
+                        theSwitch.on should_not be_truthy;
+                    });
+                });
+
+                describe(@"the slider", ^{
+
+                    context(@"when enabled in the storyboard", ^{
+                        __block WKInterfaceSlider *enabledSlider;
+
+                        beforeEach(^{
+                            enabledSlider = controller.enabledSlider;
+                        });
+
+                        it(@"should have the correct default enabled property", ^{
+                            enabledSlider.enabled should be_truthy;
+                        });
+
+                        it(@"should have the correct value", ^{
+                            enabledSlider.value should be_close_to(2.7).within(FLT_EPSILON);
+                        });
+
+                        it(@"should have the number of steps", ^{
+                            enabledSlider.numberOfSteps should equal(8);
+                        });
+
+                        it(@"should have the correct minimum", ^{
+                            enabledSlider.minimum should equal(2);
+                        });
+
+                        it(@"should have the correct maximum", ^{
+                            enabledSlider.maximum should equal(10);
+                        });
+
+                        it(@"should have the correct minimum image", ^{
+                            enabledSlider.minimumImage should equal([UIImage imageNamed:@"minus"]);
+                        });
+
+                        it(@"should have the correct maximum image", ^{
+                            enabledSlider.maximumImage should equal([UIImage imageNamed:@"plus"]);
+                        });
+
+                        it(@"should have the correct continuous value", ^{
+                            enabledSlider.continuous should be_truthy;
+                        });
+                    });
+
+                    context(@"when disabled in the storyboard", ^{
+                        __block WKInterfaceSlider *disabledSlider;
+
+                        beforeEach(^{
+                            disabledSlider = controller.disabledSlider;
+                        });
+
+                        it(@"should have the correct disabled property", ^{
+                            disabledSlider.enabled should_not be_truthy;
+                        });
+                    });
+                });
+
+                describe(@"the group", ^{
+                    context(@"single group", ^{
+                        __block WKInterfaceGroup *singleGroup;
+
+                        beforeEach(^{
+                            singleGroup = controller.singleGroup;
+                        });
+
+                        it(@"should have all of the containing interface objects specified in the storyboard", ^{
+                            singleGroup.items.count should equal(2);
+
+                            WKInterfaceImage *firstImage = singleGroup.items[0];
+                            WKInterfaceImage *secondImage = singleGroup.items[1];
+                            firstImage.image should equal([UIImage imageNamed:@"corgi.jpeg"]);
+                            secondImage.image should equal([UIImage imageNamed:@"corgi.jpeg"]);
+                        });
+
+                        it(@"should set properties inside of groups correctly", ^{
+                            singleGroup.items[1]should be_same_instance_as(controller.corgiImageInSingleGroup);
+                        });
+                    });
+
+                    context(@"nested group", ^{
+                        __block WKInterfaceGroup *nestedGroup;
+                        beforeEach(^{
+                            nestedGroup = controller.nestedGroup;
+                        });
+
+                        it(@"should correctly deserialize nested groups", ^{
+                            WKInterfaceGroup *innerGroup = nestedGroup.items.firstObject;
+                            WKInterfaceImage *image = innerGroup.items.firstObject;
+                            image.image should equal([UIImage imageNamed:@"corgi.jpeg"]);
+                        });
+                    });
+                });
+
+                describe(@"the timer", ^{
+                    __block WKInterfaceTimer *timer;
+                    beforeEach(^{
+                        timer = controller.timer;
+                    });
+
+                    it(@"should correctly set the format string with a bitmask", ^{
+                        NSCalendarUnit units;
+                        units = NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitWeekOfMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
+
+                        timer.units should equal(units);
+                    });
+
+                    it(@"should have the correct enabled property", ^{
+                        timer.enabled should be_truthy;
+                    });
+                });
+
+                it(@"should have a image (when one was specified in the storyboard)", ^{
+                    controller.image.image should equal([UIImage imageNamed:@"corgi.jpeg"]);
+                });
+
+                it(@"should have a separator (when one was specified in the storyboard)", ^{
+                    controller.separator.color should equal([UIColor darkGrayColor]);
+                });
+            });
+        });
+    });
+
     describe(@"providing an instance of a WKInterfaceController subclass that lives in a storyboard's plist, inside the test bundle", ^{
 
         context(@"when there is no storyboard matching the name", ^{
@@ -31,10 +306,10 @@ describe(@"PCKInterfaceControllerLoader", ^{
                 should raise_exception
                 .with_name(NSInvalidArgumentException)
                 .with_reason(@"No storyboard named 'NonExistantName' exists in the test target.  Did you forget to add it?");
-                
+
             });
         });
-        
+
         context(@"when there is no interface controller instance in an existing storyboard that matches the object id", ^{
             it(@"should raise an exception with a helpful message", ^{
                 ^{ [subject interfaceControllerWithStoryboardName:@"Interface"
@@ -45,7 +320,7 @@ describe(@"PCKInterfaceControllerLoader", ^{
                 .with_reason(@"No interface controller named 'NonExistantController' exists in the storyboard 'Interface'.  Please check the storyboard and try again.");
             });
         });
-        
+
         context(@"when there is an interface controller instance in an existing storyboard but its class doesn't exist in the current target", ^{
             it(@"should raise an exception with a helpful message", ^{
                 ^{ [subject interfaceControllerWithStoryboardName:@"Interface"
@@ -56,31 +331,31 @@ describe(@"PCKInterfaceControllerLoader", ^{
                 .with_reason(@"No class named 'NonExistantController' exists in the current target.  Did you forget to add it to the test target?");
             });
         });
-        
+
         context(@"when there is an interface controller matching the object id", ^{
             __block InterfaceController *controller;
-            
+
             beforeEach(^{
                 controller = [subject interfaceControllerWithStoryboardName:@"Interface"
                                                                  identifier:@"AgC-eL-Hgc"
                                                                      bundle:testBundle];
             });
-            
+
             it(@"should return the correct type of interface controller", ^{
                 controller should be_instance_of([InterfaceController class]);
             });
-            
+
             describe(@"the interface controller's properties", ^{
                 describe(@"the title label", ^{
                     __block WKInterfaceLabel *titleLabel;
                     beforeEach(^{
                         titleLabel = controller.titleLabel;
                     });
-                    
+
                     it(@"should have the correct text", ^{
                         titleLabel.text should equal(@"Some text");
                     });
-                    
+
                     it(@"should have the correct text color", ^{
                         titleLabel.textColor should equal([UIColor colorWithRed:255.0f / 255.0f
                                                                           green:125.0f / 255.0f
@@ -88,154 +363,154 @@ describe(@"PCKInterfaceControllerLoader", ^{
                                                                           alpha:1.0]);
                     });
                 });
-                
+
                 describe(@"the button", ^{
                     __block WKInterfaceButton *button;
                     beforeEach(^{
                         button = controller.actionButton;
                     });
-                    
+
                     it(@"should have the correct text", ^{
                         button.title should equal(@"actionButton");
                     });
-                    
+
                     it(@"should have the correct text color", ^{
                         button.color should equal([UIColor lightGrayColor]);
                     });
-                    
+
                     it(@"should have the correct default enabled property", ^{
                         button.enabled should be_truthy;
                     });
-                    
+
                     it(@"should allow the enabled property to be toggled programatically", ^{
                         [controller didDeactivate];
                         button.enabled should_not be_truthy;
                     });
                 });
-                
+
                 describe(@"the date", ^{
                     __block WKInterfaceDate *date;
                     beforeEach(^{
                         date = controller.date;
                     });
-                    
+
                     it(@"should display date in the correct format", ^{
                         date.format should equal(@"yy-M-d");
                     });
-                    
+
                     it(@"should display the correct color", ^{
                         date.textColor should equal([UIColor lightGrayColor]);
                     });
                 });
-                
+
                 describe(@"the switch", ^{
                     __block WKInterfaceSwitch *theSwitch;
                     beforeEach(^{
                         theSwitch = controller.theSwitch;
                     });
-                    
+
                     it(@"should have the correct default enabled property", ^{
                         theSwitch.enabled should be_truthy;
                     });
-                    
+
                     it(@"should allow the enabled property to be toggled programatically", ^{
                         [controller didDeactivate];
                         theSwitch.enabled should_not be_truthy;
                     });
-                    
+
                     it(@"should have the correct default on property", ^{
                         theSwitch.on should be_truthy;
                     });
-                    
+
                     it(@"should allow the on property to be toggled programatically", ^{
                         [controller didDeactivate];
                         theSwitch.on should_not be_truthy;
                     });
                 });
-                
+
                 describe(@"the slider", ^{
-                    
+
                     context(@"when enabled in the storyboard", ^{
                         __block WKInterfaceSlider *enabledSlider;
-                        
+
                         beforeEach(^{
                             enabledSlider = controller.enabledSlider;
                         });
-                        
+
                         it(@"should have the correct default enabled property", ^{
                             enabledSlider.enabled should be_truthy;
                         });
-                        
+
                         it(@"should have the correct value", ^{
                             enabledSlider.value should be_close_to(2.7).within(FLT_EPSILON);
                         });
-                        
+
                         it(@"should have the number of steps", ^{
                             enabledSlider.numberOfSteps should equal(8);
                         });
-                        
+
                         it(@"should have the correct minimum", ^{
                             enabledSlider.minimum should equal(2);
                         });
-                        
+
                         it(@"should have the correct maximum", ^{
                             enabledSlider.maximum should equal(10);
                         });
-                        
+
                         it(@"should have the correct minimum image", ^{
                             enabledSlider.minimumImage should equal([UIImage imageNamed:@"minus"]);
                         });
-                        
+
                         it(@"should have the correct maximum image", ^{
                             enabledSlider.maximumImage should equal([UIImage imageNamed:@"plus"]);
                         });
-                        
+
                         it(@"should have the correct continuous value", ^{
                             enabledSlider.continuous should be_truthy;
                         });
                     });
-                    
+
                     context(@"when disabled in the storyboard", ^{
                         __block WKInterfaceSlider *disabledSlider;
-                        
+
                         beforeEach(^{
                             disabledSlider = controller.disabledSlider;
                         });
-                        
+
                         it(@"should have the correct disabled property", ^{
                             disabledSlider.enabled should_not be_truthy;
                         });
                     });
                 });
-                
+
                 describe(@"the group", ^{
                     context(@"single group", ^{
                         __block WKInterfaceGroup *singleGroup;
-                        
+
                         beforeEach(^{
                             singleGroup = controller.singleGroup;
                         });
-                        
+
                         it(@"should have all of the containing interface objects specified in the storyboard", ^{
                             singleGroup.items.count should equal(2);
-                            
+
                             WKInterfaceImage *firstImage = singleGroup.items[0];
                             WKInterfaceImage *secondImage = singleGroup.items[1];
                             firstImage.image should equal([UIImage imageNamed:@"corgi.jpeg"]);
                             secondImage.image should equal([UIImage imageNamed:@"corgi.jpeg"]);
                         });
-                        
+
                         it(@"should set properties inside of groups correctly", ^{
                             singleGroup.items[1] should be_same_instance_as(controller.corgiImageInSingleGroup);
                         });
                     });
-                    
+
                     context(@"nested group", ^{
                         __block WKInterfaceGroup *nestedGroup;
                         beforeEach(^{
                             nestedGroup = controller.nestedGroup;
                         });
-                        
+
                         it(@"should correctly deserialize nested groups", ^{
                             WKInterfaceGroup *innerGroup = nestedGroup.items.firstObject;
                             WKInterfaceImage *image = innerGroup.items.firstObject;
@@ -243,37 +518,36 @@ describe(@"PCKInterfaceControllerLoader", ^{
                         });
                     });
                 });
-                
+
                 describe(@"the timer", ^{
                     __block WKInterfaceTimer *timer;
                     beforeEach(^{
                         timer = controller.timer;
                     });
-                    
+
                     it(@"should correctly set the format string with a bitmask", ^{
                         NSCalendarUnit units;
                         units = NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitWeekOfMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
 
                         timer.units should equal(units);
                     });
-                    
+
                     it(@"should have the correct enabled property", ^{
                         timer.enabled should be_truthy;
                     });
                 });
-                
+
                 it(@"should have a image (when one was specified in the storyboard)", ^{
                     controller.image.image should equal([UIImage imageNamed:@"corgi.jpeg"]);
                 });
-                
+
                 it(@"should have a separator (when one was specified in the storyboard)", ^{
                     controller.separator.color should equal([UIColor darkGrayColor]);
                 });
             });
         });
-        
+
         context(@"when there is an interface objects associated with the controller that does not have a corresponding outlet", ^{
-            
             it(@"should not throw a runtime exception, because it doesn't throw one in production", ^{
                 ^{[subject interfaceControllerWithStoryboardName:@"Interface"
                                                       identifier:@"AgC-eL-Hgc"

--- a/WatchKit/WatchKit.xcodeproj/project.pbxproj
+++ b/WatchKit/WatchKit.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		2681A5D31AE0991C00B0B753 /* WKInterfaceDeviceSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2681A5D21AE0991C00B0B753 /* WKInterfaceDeviceSpec.mm */; };
 		AE03A0391A391C5900AD4964 /* corgi.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = AE03A0381A391C5900AD4964 /* corgi.jpeg */; };
 		AE0FDC801A6ECB71006C781D /* CustomCategoryNotificationController.m in Sources */ = {isa = PBXBuildFile; fileRef = AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */; };
+		AE120D211B55865B00BAD2BC /* Rootless.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE120D201B55865B00BAD2BC /* Rootless.storyboard */; };
 		AE25D5FE1A38F6C9008A1920 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D5FD1A38F6C9008A1920 /* XCTest.framework */; };
 		AE25D6001A38F6C9008A1920 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D5FF1A38F6C9008A1920 /* CoreGraphics.framework */; };
 		AE25D6021A38F6C9008A1920 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE25D6011A38F6C9008A1920 /* UIKit.framework */; };
@@ -207,6 +208,7 @@
 		AE03A0381A391C5900AD4964 /* corgi.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = corgi.jpeg; sourceTree = "<group>"; };
 		AE0FDC7E1A6ECB71006C781D /* CustomCategoryNotificationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomCategoryNotificationController.h; sourceTree = "<group>"; };
 		AE0FDC7F1A6ECB71006C781D /* CustomCategoryNotificationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomCategoryNotificationController.m; sourceTree = "<group>"; };
+		AE120D201B55865B00BAD2BC /* Rootless.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Rootless.storyboard; sourceTree = "<group>"; };
 		AE25D5FB1A38F6C9008A1920 /* Specs.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Specs.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE25D5FD1A38F6C9008A1920 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		AE25D5FF1A38F6C9008A1920 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = /System/Library/Frameworks/CoreGraphics.framework; sourceTree = "<absolute>"; };
@@ -453,6 +455,7 @@
 				B83AC2271A5DF12400A35BD6 /* NotificationController.h */,
 				B83AC2281A5DF12400A35BD6 /* NotificationController.m */,
 				AE85C06F1A40B974009A0E4D /* plus@2x.png */,
+				AE120D201B55865B00BAD2BC /* Rootless.storyboard */,
 				AE85C0621A40A4F4009A0E4D /* SliderController.h */,
 				AE85C0631A40A4F4009A0E4D /* SliderController.m */,
 			);
@@ -748,6 +751,7 @@
 				B83C32371A4CDDE40021F1A4 /* Interface.storyboard in Resources */,
 				AE25D6091A38F6C9008A1920 /* Specs-Info.plist in Resources */,
 				AE03A0391A391C5900AD4964 /* corgi.jpeg in Resources */,
+				AE120D211B55865B00BAD2BC /* Rootless.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WatchKit/WatchKit/PCKInterfaceControllerLoader.h
+++ b/WatchKit/WatchKit/PCKInterfaceControllerLoader.h
@@ -7,6 +7,8 @@
                                  identifier:(NSString *)objectID
                                      bundle:(NSBundle *)bundle;
 
+- (id)rootInterfaceControllerForStoryboardNamed:(NSString *)storyboardName inBundle:(NSBundle *)bundle;
+
 - (id)dynamicNotificationInterfaceControllerWithStoryboardName:(NSString *)storyboardName
                                           notificationCategory:(NSString *)notificationCategoryOrNil
                                                         bundle:(NSBundle *)bundle;

--- a/WatchKit/WatchKit/PCKInterfaceControllerLoader.m
+++ b/WatchKit/WatchKit/PCKInterfaceControllerLoader.m
@@ -11,14 +11,7 @@
                                  identifier:(NSString *)objectID
                                      bundle:(NSBundle *)bundle
 {
-    NSString *pathForPlist = [bundle pathForResource:storyboardName ofType:@"plist"];
-    if (!pathForPlist) {
-        [NSException raise:NSInvalidArgumentException
-                    format:@"No storyboard named '%@' exists in the test target.  Did you forget to add it?", storyboardName];
-        return nil;
-    }
-
-    NSDictionary *dictionary = [NSDictionary dictionaryWithContentsOfFile:pathForPlist][@"controllers"];
+    NSDictionary *dictionary = [self dictionaryForStoryboardNamed:storyboardName inBundle:bundle][@"controllers"];
     NSString *controllerID = dictionary[objectID] ? objectID : [NSString stringWithFormat:@"controller-%@", objectID];
     NSDictionary *controllerProperties = dictionary[controllerID];
     if (!controllerProperties) {
@@ -26,9 +19,24 @@
                     format:@"No interface controller named '%@' exists in the storyboard '%@'.  Please check the storyboard and try again.", objectID, storyboardName];
         return nil;
     }
-    
+
     PCKDynamicWatchKitObjectProvider *provider = [[PCKDynamicWatchKitObjectProvider alloc] init];
     return [provider interfaceControllerWithProperties:controllerProperties];
+}
+
+- (id)rootInterfaceControllerForStoryboardNamed:(NSString *)storyboardName inBundle:(NSBundle *)bundle {
+    NSDictionary *dictionary = [self dictionaryForStoryboardNamed:storyboardName inBundle:bundle];
+    NSString *controllerID = dictionary[@"root"];
+
+    if(!controllerID) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"No root controller found for storyboard named '%@'.  Did you forget to set it in interface builder?", storyboardName];
+        return nil;
+    }
+
+    return [self interfaceControllerWithStoryboardName:storyboardName
+                                            identifier:controllerID
+                                                bundle:bundle];
 }
 
 - (id)dynamicNotificationInterfaceControllerWithStoryboardName:(NSString *)storyboardName
@@ -77,6 +85,25 @@
 
     PCKDynamicWatchKitObjectProvider *provider = [[PCKDynamicWatchKitObjectProvider alloc] init];
     return [provider interfaceControllerWithProperties:controllerProperties];
+}
+
+#pragma mark - Private
+
+- (NSDictionary *)dictionaryForStoryboardNamed:(NSString *)storyboardName inBundle:(NSBundle *)bundle {
+    NSString *pathForPlist = [bundle pathForResource:storyboardName ofType:@"plist"];
+    if (!pathForPlist) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"No storyboard named '%@' exists in the test target.  Did you forget to add it?", storyboardName];
+        return nil;
+    }
+
+    NSDictionary *dictionary = [NSDictionary dictionaryWithContentsOfFile:pathForPlist];
+    if (!dictionary) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"Unreadable plist for the storyboard '%@'.  Please check the storyboard and try again.", storyboardName];
+        return nil;
+    }
+    return dictionary;
 }
 
 @end


### PR DESCRIPTION
This returns the root interface controller for a given combination of storyboard name and bundle.

Please note that we were unable to test some edge cases due to Xcode currently not supporting multiple Watchkit storyboards in a target.