### PR TITLE
Fixed compiler error when targeting iOS 9.

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -10,6 +10,7 @@
   * Adds a `triggerNonSegueAction` category on WKInterfaceButton to help test non-segue actions in WatchKit
   * Adds support for testing the configuration of WKInterfaceButtons with content type group in WatchKit
   * Adds ability to toggle UIViewController spec stubs
+  * Fixed compilation errors with Xcode 7 / iOS 9
 
 ## 0.3.0
 

--- a/Foundation/SpecHelper/Extensions/NSURLConnection+Spec.m
+++ b/Foundation/SpecHelper/Extensions/NSURLConnection+Spec.m
@@ -8,6 +8,27 @@
 #import "PCKConnectionBlockDelegate.h"
 #import "PSHKFakeOperationQueue.h"
 
+#pragma mark - DefaultAuthenticationChallengeSender
+
+@interface DefaultAuthenticationChallengeSender : NSObject<NSURLAuthenticationChallengeSender>
+@end
+static DefaultAuthenticationChallengeSender* defaultSender__;
+
+@implementation DefaultAuthenticationChallengeSender
++ (DefaultAuthenticationChallengeSender*)sender {
+  if(!defaultSender__) {
+    defaultSender__ = [[DefaultAuthenticationChallengeSender alloc] init];
+  }
+  
+  return defaultSender__;
+}
+
+- (void)useCredential:(NSURLCredential *)credential forAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {}
+- (void)continueWithoutCredentialForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {}
+- (void)cancelAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {}
+@end
+
+#pragma mark - NSURLConnection+Spec
 
 static char ASSOCIATED_REQUEST_KEY;
 static char ASSOCIATED_DELEGATE_KEY;
@@ -253,12 +274,13 @@ static PSHKFakeOperationQueue *connectionsQueue__;
                                                                                   realm:nil
                                                                    authenticationMethod:nil]
                                              autorelease];
+  
     NSURLAuthenticationChallenge *challenge = [[[NSURLAuthenticationChallenge alloc] initWithProtectionSpace:protectionSpace
                                                                                           proposedCredential:credential
                                                                                         previousFailureCount:1
                                                                                              failureResponse:nil
                                                                                                        error:nil
-                                                                                                      sender:nil]
+                                                                                                      sender:[DefaultAuthenticationChallengeSender sender]]
                                                autorelease];
 
     [[self delegate] connection:self didReceiveAuthenticationChallenge:challenge];


### PR DESCRIPTION
- Using Xcode 7 Beta 5, the library test helper would fail to compile.
- The error was related to NSURLAuthenticationChallenge initWithProtectionSpace
  no longer accepting a nil sender.
- Solution was to create a default empty implementation of a sender, and pass a static instance to the
  aforementioned method.
- Confirmed all tests are passing
- Added entry to CHANGES.markdown