### PR TITLE
Fire UIAlertController actions after dismissal

### DIFF
--- a/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIAlertControllerSpec+Spec.mm
@@ -13,6 +13,7 @@ if (NSClassFromString(@"UIAlertController")) {
 describe(@"UIAlertController (spec extensions)", ^{
     __block UIAlertController *alertController;
     __block BOOL handlerWasExecuted;
+    __block BOOL presentedControllerWasDismissedBeforeActionHandlerCall;
     __block PCKAlertActionHandler handler;
     __block UIViewController *presentingController;
 
@@ -31,7 +32,10 @@ describe(@"UIAlertController (spec extensions)", ^{
     beforeEach(^{
         presentingController = [UIViewController new];
         handlerWasExecuted = NO;
-        handler = ^(UIAlertAction *) { handlerWasExecuted = YES; };
+        handler = ^(UIAlertAction *) {
+            handlerWasExecuted = YES;
+            presentedControllerWasDismissedBeforeActionHandlerCall = presentingController.presentedViewController == nil;
+        };
     });
 
     describe(@"-dismissByTappingCancelButton", ^{
@@ -45,8 +49,12 @@ describe(@"UIAlertController (spec extensions)", ^{
                         [alertController dismissByTappingCancelButton];
                     });
 
-                    it(@"should tap the cancel button regardless of where it is", ^{
+                    it(@"should call the handler for the cancel button", ^{
                         handlerWasExecuted should be_truthy;
+                    });
+
+                    it(@"should dismiss the controller before the action handler is executed", ^{
+                        presentedControllerWasDismissedBeforeActionHandlerCall should be_truthy;
                     });
                 });
 
@@ -77,8 +85,12 @@ describe(@"UIAlertController (spec extensions)", ^{
                     [alertController dismissByTappingCancelButton];
                 });
 
-                it(@"should tap the last button", ^{
+                it(@"should call the handler of the last added action", ^{
                     handlerWasExecuted should be_truthy;
+                });
+
+                it(@"should dismiss the controller before the action handler is executed", ^{
+                    presentedControllerWasDismissedBeforeActionHandlerCall should be_truthy;
                 });
 
                 it(@"should dismiss the alert controller", ^{
@@ -127,8 +139,12 @@ describe(@"UIAlertController (spec extensions)", ^{
                     [alertController dismissByTappingButtonWithTitle:@"Default"];
                 });
 
-                it(@"should tap the button", ^{
+                it(@"should call the handler for the action with the same title", ^{
                     handlerWasExecuted should be_truthy;
+                });
+
+                it(@"should dismiss the controller before the action handler is executed", ^{
+                    presentedControllerWasDismissedBeforeActionHandlerCall should be_truthy;
                 });
 
                 it(@"should dismiss the alert controller", ^{

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.m
@@ -5,19 +5,21 @@
 @implementation UIAlertController (Spec)
 
 - (void)dismissByTappingCancelButton {
-    UIAlertAction *cancelAction = [self cancelAction];
-    if (cancelAction.handler) {
-        cancelAction.handler(cancelAction);
-    }
-    [self.presentingViewController dismissViewControllerAnimated:NO completion:nil];
+    [self.presentingViewController dismissViewControllerAnimated:NO completion:^{
+        UIAlertAction *cancelAction = [self cancelAction];
+        if (cancelAction.handler) {
+            cancelAction.handler(cancelAction);
+        }
+    }];
 }
 
 - (void)dismissByTappingButtonWithTitle:(NSString *)title {
-    UIAlertAction *action = [self actionWithButtonTitle:title];
-    if (action.handler) {
-        action.handler(action);
-    }
-    [self.presentingViewController dismissViewControllerAnimated:NO completion:nil];
+    [self.presentingViewController dismissViewControllerAnimated:NO completion:^{
+        UIAlertAction *action = [self actionWithButtonTitle:title];
+        if (action.handler) {
+            action.handler(action);
+        }
+    }];
 }
 
 #pragma mark - Private


### PR DESCRIPTION
We discovered this today while testing an action because our handler was presenting a view controller. 

Without this fix, we got errors form the PCK stub because the presentedViewController is not nil.

This is consistent with how things work on the iOS 8.4 simulator, at least.