### PR TITLE
Cocoapods spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ xcuserdata
 */*.xcodeproj/*.xcworkspace*
 build
 .DS_Store
-
+CocoaPodsSampleProject/Pods/
+CocoaPodsSampleProject/build
+CocoaPodsSampleProject/CocoaPodsSampleProject.xcworkspace/

--- a/CocoaPodsSampleProject/CocoaPodsSampleProject.xcodeproj/project.pbxproj
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProject.xcodeproj/project.pbxproj
@@ -1,0 +1,642 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1F19F5164952D01402176DFD /* libPods-CocoaPodsSampleProject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 54BF582F01A21DB0B57E2406 /* libPods-CocoaPodsSampleProject.a */; };
+		AE83D3451B87AF25001990B1 /* NSArraySpec+PivotalCore.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE83D3441B87AF25001990B1 /* NSArraySpec+PivotalCore.mm */; };
+		AE83D34F1B87AFFE001990B1 /* NSDataSpec+PivotalCore.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE83D3461B87AFFE001990B1 /* NSDataSpec+PivotalCore.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		AE83D3501B87AFFE001990B1 /* NSDictionarySpec+QueryStringSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE83D3471B87AFFE001990B1 /* NSDictionarySpec+QueryStringSpec.mm */; };
+		AE83D3511B87AFFE001990B1 /* NSDictionarySpec+TypesafeExtraction.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE83D3481B87AFFE001990B1 /* NSDictionarySpec+TypesafeExtraction.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		AE83D3521B87AFFE001990B1 /* NSObjectSpec+MethodDecoration.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE83D3491B87AFFE001990B1 /* NSObjectSpec+MethodDecoration.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		AE83D3531B87AFFE001990B1 /* NSObjectSpec+MethodRedirection.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE83D34A1B87AFFE001990B1 /* NSObjectSpec+MethodRedirection.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		AE83D3541B87AFFE001990B1 /* NSStringSpec+PivotalCore.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE83D34B1B87AFFE001990B1 /* NSStringSpec+PivotalCore.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		AE83D3561B87AFFE001990B1 /* NSURLSpec+QueryComponents.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE83D34D1B87AFFE001990B1 /* NSURLSpec+QueryComponents.mm */; };
+		AE92F7701B87A1E7008C3B2D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = AE92F76F1B87A1E7008C3B2D /* main.m */; };
+		AE92F7731B87A1E7008C3B2D /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AE92F7721B87A1E7008C3B2D /* AppDelegate.m */; };
+		AE92F7761B87A1E7008C3B2D /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AE92F7751B87A1E7008C3B2D /* ViewController.m */; };
+		AE92F7791B87A1E7008C3B2D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE92F7771B87A1E7008C3B2D /* Main.storyboard */; };
+		AE92F77B1B87A1E7008C3B2D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AE92F77A1B87A1E7008C3B2D /* Images.xcassets */; };
+		AE92F77E1B87A1E7008C3B2D /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = AE92F77C1B87A1E7008C3B2D /* LaunchScreen.xib */; };
+		AED1A7171B8B873A0063EEAF /* PCKCompletionHandlerSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AED1A7141B8B873A0063EEAF /* PCKCompletionHandlerSpec.mm */; };
+		AED1A7181B8B873A0063EEAF /* PCKErrorBlockSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AED1A7151B8B873A0063EEAF /* PCKErrorBlockSpec.mm */; };
+		AED1A7191B8B873A0063EEAF /* PCKMaybeBlockSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AED1A7161B8B873A0063EEAF /* PCKMaybeBlockSpec.mm */; };
+		AED1A71D1B8B87640063EEAF /* PCKXMLParserSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AED1A71B1B8B87640063EEAF /* PCKXMLParserSpec.mm */; };
+		AED1A7221B8B87F10063EEAF /* NSAttributedString+PivotalCoreKit_UIKitSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AED1A7201B8B87F10063EEAF /* NSAttributedString+PivotalCoreKit_UIKitSpec.mm */; };
+		AED1A7231B8B87F10063EEAF /* NSString+PivotalCoreKit_UIKitSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AED1A7211B8B87F10063EEAF /* NSString+PivotalCoreKit_UIKitSpec.mm */; };
+		AED1A7281B8B88290063EEAF /* UIBarButtonItem+ButtonSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AED1A7241B8B88290063EEAF /* UIBarButtonItem+ButtonSpec.mm */; };
+		AED1A7291B8B88290063EEAF /* UIImage+PivotalCoreSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AED1A7251B8B88290063EEAF /* UIImage+PivotalCoreSpec.mm */; };
+		AED1A72A1B8B88290063EEAF /* UIImageView+PivotalCoreSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AED1A7261B8B88290063EEAF /* UIImageView+PivotalCoreSpec.mm */; };
+		AED1A72B1B8B88290063EEAF /* UIView+PivotalCoreSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AED1A7271B8B88290063EEAF /* UIView+PivotalCoreSpec.mm */; };
+		AED1A72E1B8B88DD0063EEAF /* UIImage+Spec.m in Sources */ = {isa = PBXBuildFile; fileRef = AED1A72D1B8B88DD0063EEAF /* UIImage+Spec.m */; };
+		AED1A7301B8B8AE70063EEAF /* pivotallabs-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = AED1A72F1B8B8AE70063EEAF /* pivotallabs-logo.png */; };
+		AED1A7341B8B8CCE0063EEAF /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AED1A7331B8B8CCE0063EEAF /* Default-568h@2x.png */; };
+		B3D179175CA86FB888C692D9 /* libPods-CocoaPodsSampleProjectTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E20968933F4580FEFAFC45F /* libPods-CocoaPodsSampleProjectTests.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		AE92F7841B87A1E7008C3B2D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AE92F7621B87A1E7008C3B2D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AE92F7691B87A1E7008C3B2D;
+			remoteInfo = CocoaPodsSampleProject;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		379C64BF0789C053417A9396 /* Pods-CocoaPodsSampleProjectTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsSampleProjectTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CocoaPodsSampleProjectTests/Pods-CocoaPodsSampleProjectTests.release.xcconfig"; sourceTree = "<group>"; };
+		39CE5D887DC5D0864010AF3E /* Pods-CocoaPodsSampleProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsSampleProjectTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CocoaPodsSampleProjectTests/Pods-CocoaPodsSampleProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
+		3E20968933F4580FEFAFC45F /* libPods-CocoaPodsSampleProjectTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CocoaPodsSampleProjectTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		54BF582F01A21DB0B57E2406 /* libPods-CocoaPodsSampleProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CocoaPodsSampleProject.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8CDD5EAA14EEAB6EBADA9F7D /* Pods-CocoaPodsSampleProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsSampleProject.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CocoaPodsSampleProject/Pods-CocoaPodsSampleProject.debug.xcconfig"; sourceTree = "<group>"; };
+		AE83D3441B87AF25001990B1 /* NSArraySpec+PivotalCore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSArraySpec+PivotalCore.mm"; path = "../../Foundation/Spec/Extensions/NSArraySpec+PivotalCore.mm"; sourceTree = "<group>"; };
+		AE83D3461B87AFFE001990B1 /* NSDataSpec+PivotalCore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSDataSpec+PivotalCore.mm"; path = "../../Foundation/Spec/Extensions/NSDataSpec+PivotalCore.mm"; sourceTree = "<group>"; };
+		AE83D3471B87AFFE001990B1 /* NSDictionarySpec+QueryStringSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSDictionarySpec+QueryStringSpec.mm"; path = "../../Foundation/Spec/Extensions/NSDictionarySpec+QueryStringSpec.mm"; sourceTree = "<group>"; };
+		AE83D3481B87AFFE001990B1 /* NSDictionarySpec+TypesafeExtraction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSDictionarySpec+TypesafeExtraction.mm"; path = "../../Foundation/Spec/Extensions/NSDictionarySpec+TypesafeExtraction.mm"; sourceTree = "<group>"; };
+		AE83D3491B87AFFE001990B1 /* NSObjectSpec+MethodDecoration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSObjectSpec+MethodDecoration.mm"; path = "../../Foundation/Spec/Extensions/NSObjectSpec+MethodDecoration.mm"; sourceTree = "<group>"; };
+		AE83D34A1B87AFFE001990B1 /* NSObjectSpec+MethodRedirection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSObjectSpec+MethodRedirection.mm"; path = "../../Foundation/Spec/Extensions/NSObjectSpec+MethodRedirection.mm"; sourceTree = "<group>"; };
+		AE83D34B1B87AFFE001990B1 /* NSStringSpec+PivotalCore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSStringSpec+PivotalCore.mm"; path = "../../Foundation/Spec/Extensions/NSStringSpec+PivotalCore.mm"; sourceTree = "<group>"; };
+		AE83D34C1B87AFFE001990B1 /* NSURLConnectionSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSURLConnectionSpec+Spec.mm"; path = "../../Foundation/Spec/Extensions/NSURLConnectionSpec+Spec.mm"; sourceTree = "<group>"; };
+		AE83D34D1B87AFFE001990B1 /* NSURLSpec+QueryComponents.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSURLSpec+QueryComponents.mm"; path = "../../Foundation/Spec/Extensions/NSURLSpec+QueryComponents.mm"; sourceTree = "<group>"; };
+		AE83D34E1B87AFFE001990B1 /* NSUUIDSpec+Spec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSUUIDSpec+Spec.mm"; path = "../../Foundation/Spec/Extensions/NSUUIDSpec+Spec.mm"; sourceTree = "<group>"; };
+		AE92F76A1B87A1E7008C3B2D /* CocoaPodsSampleProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CocoaPodsSampleProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE92F76E1B87A1E7008C3B2D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AE92F76F1B87A1E7008C3B2D /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		AE92F7711B87A1E7008C3B2D /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		AE92F7721B87A1E7008C3B2D /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		AE92F7741B87A1E7008C3B2D /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		AE92F7751B87A1E7008C3B2D /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		AE92F7781B87A1E7008C3B2D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		AE92F77A1B87A1E7008C3B2D /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		AE92F77D1B87A1E7008C3B2D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		AE92F7831B87A1E7008C3B2D /* CocoaPodsSampleProjectTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CocoaPodsSampleProjectTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE92F7881B87A1E7008C3B2D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AED1A7141B8B873A0063EEAF /* PCKCompletionHandlerSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = PCKCompletionHandlerSpec.mm; path = ../../Foundation/Spec/Monads/PCKCompletionHandlerSpec.mm; sourceTree = "<group>"; };
+		AED1A7151B8B873A0063EEAF /* PCKErrorBlockSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = PCKErrorBlockSpec.mm; path = ../../Foundation/Spec/Monads/PCKErrorBlockSpec.mm; sourceTree = "<group>"; };
+		AED1A7161B8B873A0063EEAF /* PCKMaybeBlockSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = PCKMaybeBlockSpec.mm; path = ../../Foundation/Spec/Monads/PCKMaybeBlockSpec.mm; sourceTree = "<group>"; };
+		AED1A71B1B8B87640063EEAF /* PCKXMLParserSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = PCKXMLParserSpec.mm; path = ../../Foundation/Spec/Parsers/PCKXMLParserSpec.mm; sourceTree = "<group>"; };
+		AED1A7201B8B87F10063EEAF /* NSAttributedString+PivotalCoreKit_UIKitSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSAttributedString+PivotalCoreKit_UIKitSpec.mm"; path = "../../UIKit/Spec/Extensions/NSAttributedString+PivotalCoreKit_UIKitSpec.mm"; sourceTree = "<group>"; };
+		AED1A7211B8B87F10063EEAF /* NSString+PivotalCoreKit_UIKitSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSString+PivotalCoreKit_UIKitSpec.mm"; path = "../../UIKit/Spec/Extensions/NSString+PivotalCoreKit_UIKitSpec.mm"; sourceTree = "<group>"; };
+		AED1A7241B8B88290063EEAF /* UIBarButtonItem+ButtonSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "UIBarButtonItem+ButtonSpec.mm"; path = "../../UIKit/Spec/Extensions/UIBarButtonItem+ButtonSpec.mm"; sourceTree = "<group>"; };
+		AED1A7251B8B88290063EEAF /* UIImage+PivotalCoreSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "UIImage+PivotalCoreSpec.mm"; path = "../../UIKit/Spec/Extensions/UIImage+PivotalCoreSpec.mm"; sourceTree = "<group>"; };
+		AED1A7261B8B88290063EEAF /* UIImageView+PivotalCoreSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "UIImageView+PivotalCoreSpec.mm"; path = "../../UIKit/Spec/Extensions/UIImageView+PivotalCoreSpec.mm"; sourceTree = "<group>"; };
+		AED1A7271B8B88290063EEAF /* UIView+PivotalCoreSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "UIView+PivotalCoreSpec.mm"; path = "../../UIKit/Spec/Extensions/UIView+PivotalCoreSpec.mm"; sourceTree = "<group>"; };
+		AED1A72C1B8B88DD0063EEAF /* UIImage+Spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+Spec.h"; path = "../../UIKit/SpecHelper/Extensions/UIImage+Spec.h"; sourceTree = "<group>"; };
+		AED1A72D1B8B88DD0063EEAF /* UIImage+Spec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Spec.m"; path = "../../UIKit/SpecHelper/Extensions/UIImage+Spec.m"; sourceTree = "<group>"; };
+		AED1A72F1B8B8AE70063EEAF /* pivotallabs-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "pivotallabs-logo.png"; path = "../../UIKit/Spec/Fixtures/Images/pivotallabs-logo.png"; sourceTree = "<group>"; };
+		AED1A7311B8B8C230063EEAF /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "../UIKit/Default-568h@2x.png"; sourceTree = "<group>"; };
+		AED1A7331B8B8CCE0063EEAF /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "../UIKit/Default-568h@2x.png"; sourceTree = "<group>"; };
+		F7F08E43640F1B56F6F06068 /* Pods-CocoaPodsSampleProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsSampleProject.release.xcconfig"; path = "Pods/Target Support Files/Pods-CocoaPodsSampleProject/Pods-CocoaPodsSampleProject.release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AE92F7671B87A1E7008C3B2D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F19F5164952D01402176DFD /* libPods-CocoaPodsSampleProject.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AE92F7801B87A1E7008C3B2D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B3D179175CA86FB888C692D9 /* libPods-CocoaPodsSampleProjectTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4722B2C08E555C7B4346139D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				54BF582F01A21DB0B57E2406 /* libPods-CocoaPodsSampleProject.a */,
+				3E20968933F4580FEFAFC45F /* libPods-CocoaPodsSampleProjectTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		AE92F7611B87A1E7008C3B2D = {
+			isa = PBXGroup;
+			children = (
+				AED1A7331B8B8CCE0063EEAF /* Default-568h@2x.png */,
+				AED1A7311B8B8C230063EEAF /* Default-568h@2x.png */,
+				AE92F76C1B87A1E7008C3B2D /* CocoaPodsSampleProject */,
+				AE92F7861B87A1E7008C3B2D /* CocoaPodsSampleProjectTests */,
+				AE92F76B1B87A1E7008C3B2D /* Products */,
+				BDE6E2C212728B796D3E72E1 /* Pods */,
+				4722B2C08E555C7B4346139D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		AE92F76B1B87A1E7008C3B2D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AE92F76A1B87A1E7008C3B2D /* CocoaPodsSampleProject.app */,
+				AE92F7831B87A1E7008C3B2D /* CocoaPodsSampleProjectTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		AE92F76C1B87A1E7008C3B2D /* CocoaPodsSampleProject */ = {
+			isa = PBXGroup;
+			children = (
+				AE92F7711B87A1E7008C3B2D /* AppDelegate.h */,
+				AE92F7721B87A1E7008C3B2D /* AppDelegate.m */,
+				AE92F7741B87A1E7008C3B2D /* ViewController.h */,
+				AE92F7751B87A1E7008C3B2D /* ViewController.m */,
+				AE92F7771B87A1E7008C3B2D /* Main.storyboard */,
+				AE92F77A1B87A1E7008C3B2D /* Images.xcassets */,
+				AE92F77C1B87A1E7008C3B2D /* LaunchScreen.xib */,
+				AE92F76D1B87A1E7008C3B2D /* Supporting Files */,
+			);
+			path = CocoaPodsSampleProject;
+			sourceTree = "<group>";
+		};
+		AE92F76D1B87A1E7008C3B2D /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				AE92F76E1B87A1E7008C3B2D /* Info.plist */,
+				AE92F76F1B87A1E7008C3B2D /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		AE92F7861B87A1E7008C3B2D /* CocoaPodsSampleProjectTests */ = {
+			isa = PBXGroup;
+			children = (
+				AED1A71F1B8B87AB0063EEAF /* UIKitCoreSpecs */,
+				AED1A71E1B8B877A0063EEAF /* FoundationCoreSpecs */,
+				AE92F7871B87A1E7008C3B2D /* Supporting Files */,
+			);
+			path = CocoaPodsSampleProjectTests;
+			sourceTree = "<group>";
+		};
+		AE92F7871B87A1E7008C3B2D /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				AED1A72F1B8B8AE70063EEAF /* pivotallabs-logo.png */,
+				AE92F7881B87A1E7008C3B2D /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		AED1A71E1B8B877A0063EEAF /* FoundationCoreSpecs */ = {
+			isa = PBXGroup;
+			children = (
+				AE83D3441B87AF25001990B1 /* NSArraySpec+PivotalCore.mm */,
+				AE83D3461B87AFFE001990B1 /* NSDataSpec+PivotalCore.mm */,
+				AE83D3471B87AFFE001990B1 /* NSDictionarySpec+QueryStringSpec.mm */,
+				AE83D3481B87AFFE001990B1 /* NSDictionarySpec+TypesafeExtraction.mm */,
+				AE83D3491B87AFFE001990B1 /* NSObjectSpec+MethodDecoration.mm */,
+				AE83D34A1B87AFFE001990B1 /* NSObjectSpec+MethodRedirection.mm */,
+				AE83D34B1B87AFFE001990B1 /* NSStringSpec+PivotalCore.mm */,
+				AE83D34C1B87AFFE001990B1 /* NSURLConnectionSpec+Spec.mm */,
+				AE83D34D1B87AFFE001990B1 /* NSURLSpec+QueryComponents.mm */,
+				AE83D34E1B87AFFE001990B1 /* NSUUIDSpec+Spec.mm */,
+				AED1A7141B8B873A0063EEAF /* PCKCompletionHandlerSpec.mm */,
+				AED1A7151B8B873A0063EEAF /* PCKErrorBlockSpec.mm */,
+				AED1A7161B8B873A0063EEAF /* PCKMaybeBlockSpec.mm */,
+				AED1A71B1B8B87640063EEAF /* PCKXMLParserSpec.mm */,
+			);
+			name = FoundationCoreSpecs;
+			sourceTree = "<group>";
+		};
+		AED1A71F1B8B87AB0063EEAF /* UIKitCoreSpecs */ = {
+			isa = PBXGroup;
+			children = (
+				AED1A72C1B8B88DD0063EEAF /* UIImage+Spec.h */,
+				AED1A72D1B8B88DD0063EEAF /* UIImage+Spec.m */,
+				AED1A7241B8B88290063EEAF /* UIBarButtonItem+ButtonSpec.mm */,
+				AED1A7251B8B88290063EEAF /* UIImage+PivotalCoreSpec.mm */,
+				AED1A7261B8B88290063EEAF /* UIImageView+PivotalCoreSpec.mm */,
+				AED1A7271B8B88290063EEAF /* UIView+PivotalCoreSpec.mm */,
+				AED1A7201B8B87F10063EEAF /* NSAttributedString+PivotalCoreKit_UIKitSpec.mm */,
+				AED1A7211B8B87F10063EEAF /* NSString+PivotalCoreKit_UIKitSpec.mm */,
+			);
+			name = UIKitCoreSpecs;
+			sourceTree = "<group>";
+		};
+		BDE6E2C212728B796D3E72E1 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				8CDD5EAA14EEAB6EBADA9F7D /* Pods-CocoaPodsSampleProject.debug.xcconfig */,
+				F7F08E43640F1B56F6F06068 /* Pods-CocoaPodsSampleProject.release.xcconfig */,
+				39CE5D887DC5D0864010AF3E /* Pods-CocoaPodsSampleProjectTests.debug.xcconfig */,
+				379C64BF0789C053417A9396 /* Pods-CocoaPodsSampleProjectTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AE92F7691B87A1E7008C3B2D /* CocoaPodsSampleProject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AE92F78D1B87A1E7008C3B2D /* Build configuration list for PBXNativeTarget "CocoaPodsSampleProject" */;
+			buildPhases = (
+				A8390C82DEB9A6BAE8A2ACD6 /* Check Pods Manifest.lock */,
+				AE92F7661B87A1E7008C3B2D /* Sources */,
+				AE92F7671B87A1E7008C3B2D /* Frameworks */,
+				AE92F7681B87A1E7008C3B2D /* Resources */,
+				D6551BEE56135C1F20DC8E48 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CocoaPodsSampleProject;
+			productName = CocoaPodsSampleProject;
+			productReference = AE92F76A1B87A1E7008C3B2D /* CocoaPodsSampleProject.app */;
+			productType = "com.apple.product-type.application";
+		};
+		AE92F7821B87A1E7008C3B2D /* CocoaPodsSampleProjectTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AE92F7901B87A1E7008C3B2D /* Build configuration list for PBXNativeTarget "CocoaPodsSampleProjectTests" */;
+			buildPhases = (
+				980590A16B5215310D47B0E2 /* Check Pods Manifest.lock */,
+				AE92F77F1B87A1E7008C3B2D /* Sources */,
+				AE92F7801B87A1E7008C3B2D /* Frameworks */,
+				AE92F7811B87A1E7008C3B2D /* Resources */,
+				57A98DA6492EA24F5A242C17 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AE92F7851B87A1E7008C3B2D /* PBXTargetDependency */,
+			);
+			name = CocoaPodsSampleProjectTests;
+			productName = CocoaPodsSampleProjectTests;
+			productReference = AE92F7831B87A1E7008C3B2D /* CocoaPodsSampleProjectTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AE92F7621B87A1E7008C3B2D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0640;
+				ORGANIZATIONNAME = pivotal;
+				TargetAttributes = {
+					AE92F7691B87A1E7008C3B2D = {
+						CreatedOnToolsVersion = 6.4;
+					};
+					AE92F7821B87A1E7008C3B2D = {
+						CreatedOnToolsVersion = 6.4;
+						TestTargetID = AE92F7691B87A1E7008C3B2D;
+					};
+				};
+			};
+			buildConfigurationList = AE92F7651B87A1E7008C3B2D /* Build configuration list for PBXProject "CocoaPodsSampleProject" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = AE92F7611B87A1E7008C3B2D;
+			productRefGroup = AE92F76B1B87A1E7008C3B2D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AE92F7691B87A1E7008C3B2D /* CocoaPodsSampleProject */,
+				AE92F7821B87A1E7008C3B2D /* CocoaPodsSampleProjectTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AE92F7681B87A1E7008C3B2D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AED1A7341B8B8CCE0063EEAF /* Default-568h@2x.png in Resources */,
+				AE92F7791B87A1E7008C3B2D /* Main.storyboard in Resources */,
+				AE92F77E1B87A1E7008C3B2D /* LaunchScreen.xib in Resources */,
+				AE92F77B1B87A1E7008C3B2D /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AE92F7811B87A1E7008C3B2D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AED1A7301B8B8AE70063EEAF /* pivotallabs-logo.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		57A98DA6492EA24F5A242C17 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CocoaPodsSampleProjectTests/Pods-CocoaPodsSampleProjectTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		980590A16B5215310D47B0E2 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		A8390C82DEB9A6BAE8A2ACD6 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		D6551BEE56135C1F20DC8E48 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CocoaPodsSampleProject/Pods-CocoaPodsSampleProject-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AE92F7661B87A1E7008C3B2D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE92F7761B87A1E7008C3B2D /* ViewController.m in Sources */,
+				AE92F7731B87A1E7008C3B2D /* AppDelegate.m in Sources */,
+				AE92F7701B87A1E7008C3B2D /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AE92F77F1B87A1E7008C3B2D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AED1A7221B8B87F10063EEAF /* NSAttributedString+PivotalCoreKit_UIKitSpec.mm in Sources */,
+				AED1A7291B8B88290063EEAF /* UIImage+PivotalCoreSpec.mm in Sources */,
+				AED1A72A1B8B88290063EEAF /* UIImageView+PivotalCoreSpec.mm in Sources */,
+				AED1A7231B8B87F10063EEAF /* NSString+PivotalCoreKit_UIKitSpec.mm in Sources */,
+				AE83D3531B87AFFE001990B1 /* NSObjectSpec+MethodRedirection.mm in Sources */,
+				AE83D34F1B87AFFE001990B1 /* NSDataSpec+PivotalCore.mm in Sources */,
+				AED1A7171B8B873A0063EEAF /* PCKCompletionHandlerSpec.mm in Sources */,
+				AE83D3511B87AFFE001990B1 /* NSDictionarySpec+TypesafeExtraction.mm in Sources */,
+				AED1A7281B8B88290063EEAF /* UIBarButtonItem+ButtonSpec.mm in Sources */,
+				AE83D3521B87AFFE001990B1 /* NSObjectSpec+MethodDecoration.mm in Sources */,
+				AE83D3541B87AFFE001990B1 /* NSStringSpec+PivotalCore.mm in Sources */,
+				AE83D3561B87AFFE001990B1 /* NSURLSpec+QueryComponents.mm in Sources */,
+				AE83D3451B87AF25001990B1 /* NSArraySpec+PivotalCore.mm in Sources */,
+				AED1A72E1B8B88DD0063EEAF /* UIImage+Spec.m in Sources */,
+				AED1A71D1B8B87640063EEAF /* PCKXMLParserSpec.mm in Sources */,
+				AED1A7181B8B873A0063EEAF /* PCKErrorBlockSpec.mm in Sources */,
+				AED1A7191B8B873A0063EEAF /* PCKMaybeBlockSpec.mm in Sources */,
+				AED1A72B1B8B88290063EEAF /* UIView+PivotalCoreSpec.mm in Sources */,
+				AE83D3501B87AFFE001990B1 /* NSDictionarySpec+QueryStringSpec.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AE92F7851B87A1E7008C3B2D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AE92F7691B87A1E7008C3B2D /* CocoaPodsSampleProject */;
+			targetProxy = AE92F7841B87A1E7008C3B2D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		AE92F7771B87A1E7008C3B2D /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AE92F7781B87A1E7008C3B2D /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		AE92F77C1B87A1E7008C3B2D /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AE92F77D1B87A1E7008C3B2D /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		AE92F78B1B87A1E7008C3B2D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AE92F78C1B87A1E7008C3B2D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		AE92F78E1B87A1E7008C3B2D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8CDD5EAA14EEAB6EBADA9F7D /* Pods-CocoaPodsSampleProject.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = CocoaPodsSampleProject/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		AE92F78F1B87A1E7008C3B2D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F7F08E43640F1B56F6F06068 /* Pods-CocoaPodsSampleProject.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = CocoaPodsSampleProject/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		AE92F7911B87A1E7008C3B2D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 39CE5D887DC5D0864010AF3E /* Pods-CocoaPodsSampleProjectTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = CocoaPodsSampleProjectTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CocoaPodsSampleProject.app/CocoaPodsSampleProject";
+			};
+			name = Debug;
+		};
+		AE92F7921B87A1E7008C3B2D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 379C64BF0789C053417A9396 /* Pods-CocoaPodsSampleProjectTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = CocoaPodsSampleProjectTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CocoaPodsSampleProject.app/CocoaPodsSampleProject";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AE92F7651B87A1E7008C3B2D /* Build configuration list for PBXProject "CocoaPodsSampleProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AE92F78B1B87A1E7008C3B2D /* Debug */,
+				AE92F78C1B87A1E7008C3B2D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AE92F78D1B87A1E7008C3B2D /* Build configuration list for PBXNativeTarget "CocoaPodsSampleProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AE92F78E1B87A1E7008C3B2D /* Debug */,
+				AE92F78F1B87A1E7008C3B2D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AE92F7901B87A1E7008C3B2D /* Build configuration list for PBXNativeTarget "CocoaPodsSampleProjectTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AE92F7911B87A1E7008C3B2D /* Debug */,
+				AE92F7921B87A1E7008C3B2D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AE92F7621B87A1E7008C3B2D /* Project object */;
+}

--- a/CocoaPodsSampleProject/CocoaPodsSampleProject/AppDelegate.h
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProject/AppDelegate.h
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end
+

--- a/CocoaPodsSampleProject/CocoaPodsSampleProject/AppDelegate.m
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProject/AppDelegate.m
@@ -1,0 +1,14 @@
+#import "AppDelegate.h"
+#import "Foundation+PivotalCore.h"
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application
+didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    NSLog(@"================> %@", [@"this_string_was_originally_snake_cased" stringByCamelizing]);
+    
+    return YES;
+}
+
+@end

--- a/CocoaPodsSampleProject/CocoaPodsSampleProject/Base.lproj/LaunchScreen.xib
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProject/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 pivotal. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CocoaPodsSampleProject" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/CocoaPodsSampleProject/CocoaPodsSampleProject/Base.lproj/Main.storyboard
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProject/Base.lproj/Main.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/CocoaPodsSampleProject/CocoaPodsSampleProject/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProject/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/CocoaPodsSampleProject/CocoaPodsSampleProject/Info.plist
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProject/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.pivotal.pck.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/CocoaPodsSampleProject/CocoaPodsSampleProject/ViewController.h
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProject/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  CocoaPodsSampleProject
+//
+//  Created by pivotal on 8/21/15.
+//  Copyright (c) 2015 pivotal. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/CocoaPodsSampleProject/CocoaPodsSampleProject/ViewController.m
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProject/ViewController.m
@@ -1,0 +1,27 @@
+//
+//  ViewController.m
+//  CocoaPodsSampleProject
+//
+//  Created by pivotal on 8/21/15.
+//  Copyright (c) 2015 pivotal. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view, typically from a nib.
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+@end

--- a/CocoaPodsSampleProject/CocoaPodsSampleProject/main.m
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProject/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  CocoaPodsSampleProject
+//
+//  Created by pivotal on 8/21/15.
+//  Copyright (c) 2015 pivotal. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/CocoaPodsSampleProject/CocoaPodsSampleProjectTests/Info.plist
+++ b/CocoaPodsSampleProject/CocoaPodsSampleProjectTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.pivotal.pck.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/CocoaPodsSampleProject/Podfile
+++ b/CocoaPodsSampleProject/Podfile
@@ -1,0 +1,7 @@
+target 'CocoaPodsSampleProject' do
+  pod 'PivotalCoreKit', path: "../"
+end
+
+target 'CocoaPodsSampleProjectTests' do
+  pod 'Cedar'
+end

--- a/CocoaPodsSampleProject/Podfile.lock
+++ b/CocoaPodsSampleProject/Podfile.lock
@@ -1,0 +1,25 @@
+PODS:
+  - Cedar (0.11.3)
+  - PivotalCoreKit (0.3.0):
+    - PivotalCoreKit/Core (= 0.3.0)
+  - PivotalCoreKit/Core (0.3.0):
+    - PivotalCoreKit/Foundation/Core
+    - PivotalCoreKit/UIKit/Core
+  - PivotalCoreKit/Foundation/Core (0.3.0)
+  - PivotalCoreKit/UIKit/Core (0.3.0):
+    - PivotalCoreKit/UIKit/Core/Core-arc (= 0.3.0)
+  - PivotalCoreKit/UIKit/Core/Core-arc (0.3.0)
+
+DEPENDENCIES:
+  - Cedar
+  - PivotalCoreKit (from `../`)
+
+EXTERNAL SOURCES:
+  PivotalCoreKit:
+    :path: "../"
+
+SPEC CHECKSUMS:
+  Cedar: ab1ea4e5c8af4ee4a8fa0452936679861876dc80
+  PivotalCoreKit: 3dab7cf9bff77eb49ce7ffc7a84e57fa8591f033
+
+COCOAPODS: 0.38.2

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ BUILD_SDK_VERSION = ENV['BUILD_SDK_VERSION'] || ""
 SIMULATOR_VERSIONS = ENV['SIMULATOR_VERSIONS'] || "8.4"
 SIMULATOR_DEVICES = ENV['SIMULATOR_DEVICES'] || "iPhone 5s"
 BUILD_DIR = File.join(File.dirname(__FILE__), "build")
+COCOAPODS_SAMPLE_PROJECT_DIR = File.join(File.dirname(__FILE__), "CocoaPodsSampleProject")
 
 require 'tmpdir'
 
@@ -10,7 +11,7 @@ def build_dir(effective_platform_name)
   File.join(BUILD_DIR, CONFIGURATION + effective_platform_name)
 end
 
-def system_or_exit(cmd, env_overrides = {}, stdout = nil)
+def system_or_exit(cmd, env_overrides: {}, stdout: nil, error_message: "******** Build failed ********")
   puts "Executing #{cmd}"
   cmd += " >#{stdout}" if stdout
 
@@ -21,7 +22,7 @@ def system_or_exit(cmd, env_overrides = {}, stdout = nil)
   end
 
   system(cmd) or begin
-    puts "******** Build failed ********"
+    puts error_message
     exit(1)
   end
 
@@ -70,7 +71,7 @@ def build_and_test_scheme(scheme)
   end
 end
 
-def build_target(target, project: project, output_file: output_file, sdk: sdk)
+def build_target(target, project: project, output_file_name: output_file_name, sdk: sdk)
    command = ["xcodebuild",
    "-project",
    "#{project}.xcodeproj",
@@ -86,7 +87,7 @@ def build_target(target, project: project, output_file: output_file, sdk: sdk)
     command = command << "-sdk" << sdk
   end
 
-  system_or_exit(command.join(" "), {}, output_file)
+  system_or_exit(command.join(" "), env_overrides: {}, stdout: output_file(output_file_name))
 end
 
 desc "Trim edited files and run all specs"
@@ -107,14 +108,12 @@ namespace :foundation do
     namespace :core do
       desc "Build Foundation+PivotalCore framework for OS X"
       task :osx do
-        output_file = output_file("foundation:build:core:osx")
-        build_target("Foundation+PivotalCore", project: project, output_file: output_file)
+        build_target("Foundation+PivotalCore", project: project, output_file_name: "foundation:build:core:osx")
       end
 
       desc "Build Foundation+PivotalCore-StaticLib for iOS"
       task :ios do
-        output_file = output_file("foundation:build:core:ios")
-        build_target("Foundation+PivotalCore-StaticLib", project: project, output_file: output_file)
+        build_target("Foundation+PivotalCore-StaticLib", project: project, output_file_name: "foundation:build:core:ios")
       end
     end
 
@@ -123,8 +122,7 @@ namespace :foundation do
     namespace :framework do
       desc "Build Foundation+PivotalCore-iOS universal static framework"
       task :ios do
-        output_file = output_file("foundation:build:framework:ios")
-        build_target("Foundation+PivotalCore-iOS", project: project, output_file: output_file)
+        build_target("Foundation+PivotalCore-iOS", project: project, output_file_name: "foundation:build:framework:ios")
       end
     end
 
@@ -133,14 +131,12 @@ namespace :foundation do
     namespace :spec_helper do
       desc "Build Foundation+PivotalSpecHelper framework for OS X"
       task :osx do
-        output_file = output_file("foundation:build:spec_helper:osx")
-        build_target("Foundation+PivotalSpecHelper", project: project, output_file: output_file)
+        build_target("Foundation+PivotalSpecHelper", project: project, output_file_name: "foundation:build:spec_helper:osx")
       end
 
       desc "Build Foundation+PivotalSpecHelper-StaticLib for iOS"
       task :ios do
-        output_file = output_file("foundation:build:spec_helper:ios")
-        build_target("Foundation+PivotalSpecHelper-StaticLib", project: project, output_file: output_file)
+        build_target("Foundation+PivotalSpecHelper-StaticLib", project: project, output_file_name: "foundation:build:spec_helper:ios")
       end
     end
 
@@ -149,8 +145,7 @@ namespace :foundation do
     namespace :spec_helper_framework do
       desc "Build Foundation+PivotalSpecHelper-iOS universal static framework"
       task :ios do
-        output_file = output_file("foundation:build:spec_helper_framework:ios")
-        build_target("Foundation+PivotalSpecHelper-iOS", project: project, output_file: output_file)
+        build_target("Foundation+PivotalSpecHelper-iOS", project: project, output_file_name: "foundation:build:spec_helper_framework:ios")
       end
     end
 
@@ -160,8 +155,7 @@ namespace :foundation do
   namespace :spec do
     desc "Build and run all OS X specs"
     task :osx => ["build:core:osx", "build:spec_helper:osx"] do
-      output_file = output_file("foundation:spec:osx")
-      build_target("FoundationSpec", project: project, output_file: output_file)
+      build_target("FoundationSpec", project: project, output_file_name: "foundation:spec:osx")
 
       build_dir = build_dir("")
       env_vars = {
@@ -169,7 +163,8 @@ namespace :foundation do
         "CFFIXED_USER_HOME" => Dir.tmpdir,
         "DYLD_FRAMEWORK_PATH" => build_dir
       }
-      system_or_exit("cd #{build_dir}; ./FoundationSpec", env_vars)
+
+      system_or_exit("cd #{build_dir}; ./FoundationSpec", env_overrides: env_vars)
     end
 
     desc "Build and run all Foundation specs on iOS"
@@ -181,7 +176,7 @@ namespace :foundation do
   task :build => ["foundation:build:core", "foundation:build:spec_helper"]
   task :spec => ["foundation:spec:osx", "foundation:spec:ios"]
   task :clean do
-    system_or_exit(%Q[xcodebuild -project #{project}.xcodeproj -alltargets -configuration #{CONFIGURATION} clean SYMROOT=#{BUILD_DIR}], {}, output_file("foundation:clean"))
+    system_or_exit(%Q[xcodebuild -project #{project}.xcodeproj -alltargets -configuration #{CONFIGURATION} clean SYMROOT=#{BUILD_DIR}], env_overrides:{}, stdout:output_file("foundation:clean"))
   end
 end
 
@@ -194,8 +189,7 @@ namespace :uikit do
     namespace :core do
       desc "Build UIKit+PivotalCore-StaticLib"
       task :ios do
-        output_file = output_file("uikit:build:core:ios")
-        build_target("UIKit+PivotalCore-StaticLib", project: project, output_file: output_file)
+        build_target("UIKit+PivotalCore-StaticLib", project: project, output_file_name: "uikit:build:core:ios")
       end
     end
 
@@ -204,14 +198,12 @@ namespace :uikit do
     namespace :spec_helper do
       desc "Build UIKit+PivotalSpecHelper-StaticLib"
       task :ios do
-        output_file = output_file("uikit:build:spec_helper:ios")
-        build_target("UIKit+PivotalSpecHelper-StaticLib", project: project, output_file: output_file)
+        build_target("UIKit+PivotalSpecHelper-StaticLib", project: project, output_file_name: "uikit:build:spec_helper:ios")
       end
 
       desc "Build UIKit+PivotalSpecHelperStubs-StaticLib"
       task :ios_stubs do
-        output_file = output_file("uikit:build:spec_helper:ios_stubs")
-        build_target("UIKit+PivotalSpecHelperStubs-StaticLib", project: project, output_file: output_file)
+        build_target("UIKit+PivotalSpecHelperStubs-StaticLib", project: project, output_file_name: "uikit:build:spec_helper:ios_stubs")
       end
     end
 
@@ -220,14 +212,12 @@ namespace :uikit do
     namespace :spec_helper_framework do
       desc "Build UIKit+PivotalSpecHelper-iOS universal static framework"
       task :ios do
-        output_file = output_file("uikit:build:spec_helper_framework:ios")
-        build_target("UIKit+PivotalSpecHelper-iOS", project: project, output_file: output_file)
+        build_target("UIKit+PivotalSpecHelper-iOS", project: project, output_file_name: "uikit:build:spec_helper_framework:ios")
       end
 
       desc "Build UIKit+PivotalSpecHelperStubs-iOS universal static framework"
       task :ios_stubs do
-        output_file = output_file("uikit:build:spec_helper_framework:ios_stubs")
-        build_target("UIKit+PivotalSpecHelperStubs-iOS", project: project, output_file: output_file)
+        build_target("UIKit+PivotalSpecHelperStubs-iOS", project: project, output_file_name: "uikit:build:spec_helper_framework:ios_stubs")
       end
     end
 
@@ -244,7 +234,7 @@ namespace :uikit do
   task :build => ["build:core"]
   task :spec => ["spec:ios"]
   task :clean do
-    system_or_exit(%Q[xcodebuild -project #{project}.xcodeproj -alltargets -configuration #{CONFIGURATION} clean SYMROOT=#{BUILD_DIR}], {}, output_file("uikit:clean"))
+    system_or_exit(%Q[xcodebuild -project #{project}.xcodeproj -alltargets -configuration #{CONFIGURATION} clean SYMROOT=#{BUILD_DIR}], env_overrides: {}, stdout: output_file("uikit:clean"))
   end
 end
 
@@ -257,14 +247,12 @@ namespace :core_location do
     namespace :spec_helper do
       desc "Build CoreLocation+PivotalSpecHelper framework for OS X"
       task :osx do
-        output_file = output_file("core_location:build:spec_helper:osx")
-        build_target("CoreLocation+PivotalSpecHelper", project: project, output_file: output_file)
+        build_target("CoreLocation+PivotalSpecHelper", project: project, output_file_name: "core_location:build:spec_helper:osx")
       end
 
       desc "Build CoreLocation+PivotalSpecHelper-StaticLib for iOS"
       task :ios do
-        output_file = output_file("core_location:build:spec_helper:ios")
-        build_target("CoreLocation+PivotalSpecHelper-StaticLib", project: project, output_file: output_file)
+        build_target("CoreLocation+PivotalSpecHelper-StaticLib", project: project, output_file_name: "core_location:build:spec_helper:ios")
       end
     end
 
@@ -274,15 +262,16 @@ namespace :core_location do
   namespace :spec do
     desc "Build and run CoreLocation specs on OS X"
     task :osx => ["build:spec_helper:osx"] do
-      output_file = output_file("core_location:spec:osx")
-      build_target("CoreLocationSpec", project: project, output_file: output_file)
+
+      build_target("CoreLocationSpec", project: project, output_file_name: "core_location:spec:osx")
 
       build_dir = build_dir("")
       env_vars = {
         "DYLD_FRAMEWORK_PATH" => build_dir,
         "CEDAR_REPORTER_CLASS" => "CDRColorizedReporter"
       }
-      system_or_exit("cd #{build_dir}; ./CoreLocationSpec", env_vars)
+
+      system_or_exit("cd #{build_dir}; ./CoreLocationSpec", env_overrides: env_vars)
     end
 
     desc "Build and run CoreLocation specs on iOS"
@@ -294,7 +283,7 @@ namespace :core_location do
   task :build => ["build:spec_helper"]
   task :spec => ["spec:osx", "spec:ios"]
   task :clean do
-    system_or_exit(%Q[xcodebuild -project #{project}.xcodeproj -alltargets -configuration #{CONFIGURATION} clean SYMROOT=#{BUILD_DIR}], {}, output_file("core_location:clean"))
+    system_or_exit(%Q[xcodebuild -project #{project}.xcodeproj -alltargets -configuration #{CONFIGURATION} clean SYMROOT=#{BUILD_DIR}], env_overrides: {}, stdout: put_file("core_location:clean"))
   end
 end
 
@@ -307,8 +296,7 @@ namespace :watchkit do
   namespace :build do
     desc "Build Fake WatchKit dynamic framework for iOS"
     task :ios do
-      build_output_filename = output_file("watchkit:build:ios")
-      build_target(target, project: project, sdk: 'iphonesimulator', output_file: build_output_filename)
+      build_target(target, project: project, sdk: 'iphonesimulator', output_file_name: "watchkit:build:ios")
     end
   end
 
@@ -322,17 +310,35 @@ namespace :watchkit do
   task :spec => ["spec:ios"]
   task :build => ["build:ios"]
   task :clean do
-    system_or_exit(%Q[xcodebuild -project #{project}.xcodeproj -alltargets -configuration #{CONFIGURATION} clean SYMROOT=#{BUILD_DIR}], {}, output_file("watchkit:clean"))
+    system_or_exit(%Q[xcodebuild -project #{project}.xcodeproj -alltargets -configuration #{CONFIGURATION} clean SYMROOT=#{BUILD_DIR}], env_overrides: {}, stdout: output_file("watchkit:clean"))
   end
 end
 
 task :watchkit => ["watchkit:build", "watchkit:spec"]
 
+namespace :cocoapods do
+
+  desc "Remove Cocoapods generated files from Cocoapods sample project"
+  task :clean do
+    system_or_exit("rm -rf ~/Library/Developer/Xcode/DerivedData/*")
+    system_or_exit("rm -rf #{COCOAPODS_SAMPLE_PROJECT_DIR}/build")
+    system_or_exit("rm -rf #{COCOAPODS_SAMPLE_PROJECT_DIR}/Pods")
+    system_or_exit("rm -rf #{COCOAPODS_SAMPLE_PROJECT_DIR}/CocoaPodsSampleProject.xcworkspace")
+  end
+
+  desc "Install PCK into Cocoapods sample project"
+  task :spec => ["cocoapods:clean"] do
+    system_or_exit("/Users/pivotal/.gem/ruby/2.1.0/bin/pod --version", error_message: "This rake command tests that PCK can be installed correctly using Cocoapods.  Sadly, Cocoapods does not appear to be installed on this machine.")
+    system_or_exit("cd #{COCOAPODS_SAMPLE_PROJECT_DIR} && /Users/pivotal/.gem/ruby/2.1.0/bin/pod install", error_message: "There was an error running `pod install`.")
+    system_or_exit("cd #{COCOAPODS_SAMPLE_PROJECT_DIR} && xcodebuild -workspace CocoaPodsSampleProject.xcworkspace -scheme CocoaPodsSampleProject -sdk iphonesimulator test SYMROOT=$(PWD)/build")
+  end
+end
+
 namespace :all do
   desc "Build everything"
   task :build => ["foundation:build", "uikit:build", "core_location:build", "watchkit:build"]
   desc "Run all specs"
-  task :spec => ["foundation:spec", "uikit:spec", "core_location:spec", "watchkit:spec"]
+  task :spec => ["foundation:spec", "uikit:spec", "core_location:spec", "watchkit:spec", "cocoapods:spec"]
   desc "Clean all targets"
   task :clean => ["foundation:clean", "uikit:clean", "core_location:clean", "watchkit:clean"]
 end

--- a/UIKit/Spec/Extensions/UIImage+PivotalCoreSpec.mm
+++ b/UIKit/Spec/Extensions/UIImage+PivotalCoreSpec.mm
@@ -12,7 +12,11 @@ describe(@"UIImage_PivotalCore", ^{
     __block NSData *imageData;
 
     beforeEach(^{
-        imageData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"pivotallabs-logo" ofType:@"png"]];
+        NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
+        imageData = [NSData dataWithContentsOfFile:[testBundle pathForResource:@"pivotallabs-logo" ofType:@"png"]];
+        if(!imageData) {
+            fail(@"Image fixture: pivotallabs-logo.png is not in the Copy Resources build phase of the test target.");
+        }
         originalImage = [UIImage imageWithData:imageData scale:1.0];
         original2xImage = [UIImage imageWithData:imageData scale:2.0];
         originalImage.size should equal(CGSizeMake(223, 81));

--- a/UIKit/Spec/Extensions/UIImageView+PivotalCoreSpec.mm
+++ b/UIKit/Spec/Extensions/UIImageView+PivotalCoreSpec.mm
@@ -11,7 +11,11 @@ describe(@"UIImageView_PivotalCore", ^{
     __block UIImageView *returnedImageView;
 
     beforeEach(^{
-        imageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"Default-568h"]];
+        UIImage *image = [UIImage imageNamed:@"Default-568h"];
+        if(!image) {
+            fail(@"Image matching name: Default-568h is not found in the application bundle.");
+        }
+        imageView = [[UIImageView alloc] initWithImage:image];
         returnedImageView = [UIImageView imageViewWithImageNamed:@"Default-568h"];
     });
 

--- a/UIKit/SpecHelper/Extensions/UIImage+Spec.m
+++ b/UIKit/SpecHelper/Extensions/UIImage+Spec.m
@@ -3,13 +3,14 @@
 @implementation UIImage (Spec)
 
 - (BOOL)isEqualToByBytes:(UIImage *)otherImage {
-    NSData *imagePixelsData = (NSData *)CGDataProviderCopyData(CGImageGetDataProvider(self.CGImage));
-    NSData *otherImagePixelsData = (NSData *)CGDataProviderCopyData(CGImageGetDataProvider(otherImage.CGImage));
+    CFDataRef imagePixelsData = CGDataProviderCopyData(CGImageGetDataProvider(self.CGImage));
+    CFDataRef otherImagePixelsData = CGDataProviderCopyData(CGImageGetDataProvider(otherImage.CGImage));
     
-    BOOL comparison = [imagePixelsData isEqualToData:otherImagePixelsData];
+    BOOL comparison = CFEqual(imagePixelsData, otherImagePixelsData);
     
-    CGDataProviderRelease((CGDataProviderRef)imagePixelsData);
-    CGDataProviderRelease((CGDataProviderRef)otherImagePixelsData);
+    CFRelease(imagePixelsData);
+    CFRelease(otherImagePixelsData);
+    
     return comparison;
 }
 


### PR DESCRIPTION
This branch is a proof-of-concept showing how we could test whether or not PCK is deployable via CocoaPods.

Try it out with the new command:

`rake cocoapods:spec`

This command pulls PCK into the CocoaPodsSampleProject folder, builds an iOS app target, and runs the PCK Foundation-Core and UIKit-Core specs.  It proves that at the current revision, those two libraries are deployable via Cocoapods.

There are some potential drawbacks or omissions to this approach, but it is mean to start a conversation.  Here are the outstanding issues that I can think of:

• This branch currently only tests that two of the seven PCK static libraries (Foundation-Core, UIKit-Core)
• Maintainers will have to remember to add their spec implementations (.mm files) to the `CocoaPodsSampleProjectTests` target.