### PR TITLE
Stub loadData:MIMEType:textEncodingName:baseURL:

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -10,6 +10,7 @@
   * Adds a `triggerNonSegueAction` category on WKInterfaceButton to help test non-segue actions in WatchKit
   * Adds support for testing the configuration of WKInterfaceButtons with content type group in WatchKit
   * Adds ability to toggle UIViewController spec stubs
+  * Adds support for inspecting data loaded directly into UIWebViews
 
 ## 0.3.0
 

--- a/UIKit/Spec/Stubs/UIWebViewSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIWebViewSpec+Spec.mm
@@ -299,6 +299,33 @@ describe(@"UIWebView (spec extensions)", ^{
         });
     });
 
+    describe(@"loadData:MIMEType:textEncodingName:baseURL:", ^{
+        NSData *data = [@"some lovely data" dataUsingEncoding:NSUTF8StringEncoding];
+        NSString *mimeType = @"text/plain";
+        NSString *textEncodingName = @"UTF-POTATO";
+        NSURL *baseURL = [NSURL URLWithString:@"cats"];
+
+        beforeEach(^{
+            [webView loadData:data MIMEType:mimeType textEncodingName:textEncodingName baseURL:baseURL];
+        });
+
+        it(@"should record the data", ^{
+            expect(webView.loadedData).to(equal(data));
+        });
+
+        it(@"should record the MIME type", ^{
+            expect(webView.loadedMIMEType).to(equal(mimeType));
+        });
+
+        it(@"should record the text encoding name", ^{
+            expect(webView.loadedTextEncodingName).to(equal(textEncodingName));
+        });
+
+        it(@"should record the baseURL", ^{
+            expect(webView.loadedBaseURL).to(equal(baseURL));
+        });
+    });
+
     describe(@"when loaded from a XIB", ^{
         beforeEach(^{
             AWebViewController *controller = [[AWebViewController alloc] initWithNibName:@"AWebViewController" bundle:nil];

--- a/UIKit/SpecHelper/Stubs/UIWebView+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIWebView+Spec.h
@@ -7,6 +7,9 @@ typedef NSString *(^UIWebViewJavaScriptReturnBlock)();
 // Loaded Requests
 - (NSString *)loadedHTMLString;
 - (NSURL *)loadedBaseURL;
+- (NSData *)loadedData;
+- (NSString *)loadedMIMEType;
+- (NSString *)loadedTextEncodingName;
 
 // Faking Requests
 - (void)sendClickRequest:(NSURLRequest *)request;

--- a/UIKit/SpecHelper/Stubs/UIWebView+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIWebView+Spec.m
@@ -13,6 +13,9 @@
 @property (nonatomic, strong) NSMutableDictionary *returnValueBlocksByJavaScript;
 @property (nonatomic, strong) NSString *loadedHTMLString;
 @property (nonatomic, strong) NSURL *loadedBaseURL;
+@property (nonatomic, strong) NSData *loadedData;
+@property (nonatomic, strong) NSString *loadedMIMEType;
+@property (nonatomic, strong) NSString *loadedTextEncodingName;
 
 @end
 
@@ -88,6 +91,14 @@ static char ASSOCIATED_ATTRIBUTES_KEY;
     [self log:@"loadHTMLString:%@ baseURL:%@", string, baseURL];
 }
 
+- (void)loadData:(NSData *)data MIMEType:(NSString *)MIMEType textEncodingName:(NSString *)textEncodingName baseURL:(NSURL *)baseURL {
+    self.attributes.loadedData = data;
+    self.attributes.loadedMIMEType = MIMEType;
+    self.attributes.loadedTextEncodingName = textEncodingName;
+    self.attributes.loadedBaseURL = baseURL;
+    [self log:@"loadData:%@ MIMEType:%@ textEncodingName:%@ baseURL:%@", data, MIMEType, textEncodingName, baseURL];
+}
+
 - (NSString *)stringByEvaluatingJavaScriptFromString:(NSString *)javaScript {
     [self.attributes.javaScripts addObject:javaScript];
     UIWebViewJavaScriptReturnBlock block = [self.attributes.returnValueBlocksByJavaScript objectForKey:javaScript];
@@ -149,6 +160,18 @@ static char ASSOCIATED_ATTRIBUTES_KEY;
 
 - (NSURL *)loadedBaseURL {
     return self.attributes.loadedBaseURL;
+}
+
+- (NSData *)loadedData {
+    return self.attributes.loadedData;
+}
+
+- (NSString *)loadedMIMEType {
+    return self.attributes.loadedMIMEType;
+}
+
+- (NSString *)loadedTextEncodingName {
+    return self.attributes.loadedTextEncodingName;
 }
 
 #pragma mark Private interface


### PR DESCRIPTION
We needed to stub out this method in our current project. This saves off
its arguments into `UIWebViewAttributes`, akin to the existing stub for
`loadHTMLString:baseURL`.