### PR TITLE
updated example instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -181,7 +181,7 @@ install the correct portions of the PivotalCoreKit library, and create a new Xco
 * Navigate into PivotalCoreKit/UIKit folder, select UIKit.xcodeproj and add.
 * In root project file, choose Specs target
 * Under the "Build Phases" tab along the top of the project settings, add UIKit+PivotalSpecHelper-StaticLib to "Target Dependencies"
-* Add libUIKit+PivotalSpecHelper-StaticLib.a to the "Link Binary With Library" section
+* Add libUIKit+PivotalSpecHelper-StaticLib.a to the "Link Binary With Library" section. (Also add CoreGraphics.framework).
 * Switch to the "Build Settings" tab Add "$(SRCROOT)/Externals/PivotalCoreKit/UIKit/" to "Header Search Paths" and make it recursive
 * In the desired spec file, add #import "UIControl+Spec.h" and freely use [button tap];
 


### PR DESCRIPTION
Was setting up PVC in a new project and following the instructions in "Example, adding -[UIButton tap] to a spec target."  The build failed with the error,
```Undefined symbols for architecture x86_64:
  "_CGDataProviderCopyData", referenced from:
      -[UIImage(Spec) isEqualToByBytes:] in libUIKit+PivotalSpecHelper-StaticLib.a(UIImage+Spec.o)
  "_CGImageGetDataProvider", referenced from:
      -[UIImage(Spec) isEqualToByBytes:] in libUIKit+PivotalSpecHelper-StaticLib.a(UIImage+Spec.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)```

which is resolved if CoreGraphics.framework is imported in "Link Binary With Libraries"