### PR TITLE
Nullability annotations

### DIFF
--- a/CoreLocation/SpecHelper/Extensions/CLGeocoder+Spec.h
+++ b/CoreLocation/SpecHelper/Extensions/CLGeocoder+Spec.h
@@ -1,12 +1,16 @@
 #import <CoreLocation/CoreLocation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CLGeocoder (Spec)
 
-- (NSString *)addressString;
-- (CLLocation *)location;
+- (nullable NSString *)addressString;
+- (nullable CLLocation *)location;
 
 - (void)completeGeocodeWithPlacemarks:(NSArray *)placemarks;
 - (void)completeReverseGeocodeWithPlacemarks:(NSArray *)placemarks;
 - (void)completeGeocodeWithError:(NSError *)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CoreLocation/SpecHelper/Extensions/CLLocationManager+Spec.h
+++ b/CoreLocation/SpecHelper/Extensions/CLLocationManager+Spec.h
@@ -1,7 +1,11 @@
 #import <CoreLocation/CoreLocation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CLLocationManager (Spec)
 
 + (void)setAuthorizationStatus:(CLAuthorizationStatus)authorizationStatus;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Extensions/NSArray+PivotalCore.h
+++ b/Foundation/Core/Extensions/NSArray+PivotalCore.h
@@ -1,13 +1,17 @@
 #import <Foundation/Foundation.h>
 #import "PCKReducable.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSArray (PivotalCore)
 
-- (NSArray *)collect:(id(^)(id))collector;
-- (NSArray *)collect:(id(^)(id))collector boxNils:(BOOL)shouldBox;
+- (NSArray *)collect:(__nullable id(^)(id))collector;
+- (NSArray *)collect:(__nullable id(^)(id))collector boxNils:(BOOL)shouldBox;
 - (NSArray *)collectWithKeyPath:(NSString *)keyPath;
 
 @end
 
 @interface NSArray () <PCKReducable>
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Extensions/NSData+PivotalCore.h
+++ b/Foundation/Core/Extensions/NSData+PivotalCore.h
@@ -1,8 +1,12 @@
 #import <Foundation/NSData.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSData (PivotalCore)
 + (id)dataWithSHA1HashOfString:(NSString *)string;
 - (id)initWithSHA1HashOfString:(NSString *)string;
 
 - (NSString *)hexadecimalString;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Extensions/NSDictionary+QueryString.h
+++ b/Foundation/Core/Extensions/NSDictionary+QueryString.h
@@ -1,6 +1,10 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSDictionary (QueryString)
 + (NSDictionary *)dictionaryFromQueryString:(NSString *)queryString;
 - (NSString *)queryString;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Extensions/NSDictionary+TypesafeExtraction.h
+++ b/Foundation/Core/Extensions/NSDictionary+TypesafeExtraction.h
@@ -1,20 +1,24 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSDictionary (TypesafeExtraction)
 
-- (id)objectForKey:(id)key requiredType:(Class)type;
+- (nullable id)objectForKey:(id)key requiredType:(Class)type;
 
-- (NSString *)stringObjectForKey:(id)key;
-- (NSNumber *)numberObjectForKey:(id)key;
-- (NSDate *)dateObjectForKey:(id)key;
-- (NSDate *)dateObjectForKey:(id)key formatter:(NSDateFormatter *)formatter;
-- (NSArray *)arrayObjectForKey:(id)key;
-- (NSArray *)arrayObjectForKey:(id)key constrainedToElementsOfClass:(Class)klass;
-- (NSDictionary *)dictionaryObjectForKey:(id)key;
-- (NSURL *)URLObjectForKey:(id)key;
+- (nullable NSString *)stringObjectForKey:(id)key;
+- (nullable NSNumber *)numberObjectForKey:(id)key;
+- (nullable NSDate *)dateObjectForKey:(id)key;
+- (nullable NSDate *)dateObjectForKey:(id)key formatter:(nullable NSDateFormatter *)formatter;
+- (nullable NSArray *)arrayObjectForKey:(id)key;
+- (nullable NSArray *)arrayObjectForKey:(id)key constrainedToElementsOfClass:(Class)klass;
+- (nullable NSDictionary *)dictionaryObjectForKey:(id)key;
+- (nullable NSURL *)URLObjectForKey:(id)key;
 
 - (float)floatValueForKey:(id)key;
 - (NSInteger)integerValueForKey:(id)key;
 - (BOOL)boolValueForKey:(id)key;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Extensions/NSObject+MethodDecoration.h
+++ b/Foundation/Core/Extensions/NSObject+MethodDecoration.h
@@ -1,7 +1,11 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSObject (MethodDecoration)
 
 + (void)decorateMethod:(NSString *)methodName with:(NSString *)decoration;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Extensions/NSObject+MethodRedirection.h
+++ b/Foundation/Core/Extensions/NSObject+MethodRedirection.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface NSObject (MethodRedirection)
 
@@ -9,3 +10,5 @@
 + (void)redirectSelector:(SEL)originalSelector forClass:(Class)klass to:(SEL)newSelector andRenameItTo:(SEL)renamedSelector;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Extensions/NSString+PivotalCore.h
+++ b/Foundation/Core/Extensions/NSString+PivotalCore.h
@@ -1,5 +1,7 @@
 #import <Foundation/NSString.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSString (PivotalCore)
 
 // use NSData's NSDataBase64Encoding methods instead, such as -base64EncodedStringWithOptions:
@@ -20,3 +22,5 @@
 - (NSString *)stringByAddingPercentEscapesUsingEncoding:(NSStringEncoding)encoding includeAll:(BOOL)includeAll DEPRECATED_ATTRIBUTE;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Extensions/NSURL+QueryComponents.h
+++ b/Foundation/Core/Extensions/NSURL+QueryComponents.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSURL (QueryComponents)
 -(NSDictionary *)queryComponents;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Extensions/PCKReducable.h
+++ b/Foundation/Core/Extensions/PCKReducable.h
@@ -1,12 +1,16 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol PCKReducable <NSObject>
 
-- (id)reduce:(id(^)(id accumulator, id input))f initialValue:(id)initialValue;
-- (id)reduce:(id(^)(id accumulator, id input))f;
+- (nullable id)reduce:(__nullable id(^)(__nullable id accumulator, id input))f initialValue:(nullable id)initialValue;
+- (nullable id)reduce:(__nullable id(^)(__nullable id accumulator, id input))f;
 
 - (id)map:(id(^)(id))f;
 
 - (id)filter:(BOOL(^)(id))f;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Interfaces/PCKHTTPConnection.h
+++ b/Foundation/Core/Interfaces/PCKHTTPConnection.h
@@ -2,8 +2,12 @@
 
 @class PCKHTTPInterface;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PCKHTTPConnection : NSURLConnection
 
-- (id)initWithHTTPInterface:(PCKHTTPInterface *)interface forRequest:(NSURLRequest *)request andDelegate:(id<NSURLConnectionDelegate>)delegate;
+- (id)initWithHTTPInterface:(PCKHTTPInterface *)interface forRequest:(NSURLRequest *)request andDelegate:(nullable id<NSURLConnectionDelegate>)delegate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Interfaces/PCKHTTPConnectionDelegate.h
+++ b/Foundation/Core/Interfaces/PCKHTTPConnectionDelegate.h
@@ -3,12 +3,16 @@
 
 @class PCKHTTPInterface;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PCKHTTPConnectionDelegate : NSObject <NSURLConnectionDataDelegate>
 
-@property (nonatomic, retain) id<NSURLConnectionDelegate> delegate;
+@property (nonatomic, retain, nullable) id<NSURLConnectionDelegate> delegate;
 @property (nonatomic, assign) PCKHTTPInterface *interface;
 
-+ (id)delegateWithInterface:(PCKHTTPInterface *)interface delegate:(id<NSURLConnectionDelegate>)delegate;
-- (id)initWithInterface:(PCKHTTPInterface *)interface delegate:(id<NSURLConnectionDelegate>)delegate;
++ (id)delegateWithInterface:(nullable PCKHTTPInterface *)interface delegate:(nullable id<NSURLConnectionDelegate>)delegate;
+- (id)initWithInterface:(nullable PCKHTTPInterface *)interface delegate:(nullable id<NSURLConnectionDelegate>)delegate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Interfaces/PCKHTTPConnectionOperation.h
+++ b/Foundation/Core/Interfaces/PCKHTTPConnectionOperation.h
@@ -3,8 +3,12 @@
 
 @class PCKHTTPInterface;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PCKHTTPConnectionOperation : NSOperation <NSURLConnectionDataDelegate>
 
-- (id)initWithHTTPInterface:(PCKHTTPInterface *)interface forRequest:(NSURLRequest *)request andDelegate:(id<NSURLConnectionDelegate>)delegate;
+- (id)initWithHTTPInterface:(PCKHTTPInterface *)interface forRequest:(NSURLRequest *)request andDelegate:(nullable id<NSURLConnectionDelegate>)delegate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Interfaces/PCKHTTPInterface.h
+++ b/Foundation/Core/Interfaces/PCKHTTPInterface.h
@@ -2,7 +2,9 @@
 
 @protocol NSURLConnectionDelegate;
 
-typedef void (^RequestSetupBlock)(NSMutableURLRequest *);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^RequestSetupBlock)(NSMutableURLRequest * __nonnull);
 
 @interface PCKHTTPInterface : NSObject {
     NSURL *baseURLAndPath_, *baseSecureURLAndPath_;
@@ -12,11 +14,11 @@ typedef void (^RequestSetupBlock)(NSMutableURLRequest *);
 @property (nonatomic, readonly) NSArray *activeConnections;
 
 #pragma mark protected
-- (NSURLConnection *)connectionForPath:(NSString *)path secure:(BOOL)secure andDelegate:(id<NSURLConnectionDelegate>)delegate;
-- (NSURLConnection *)connectionForPath:(NSString *)path secure:(BOOL)secure andDelegate:(id<NSURLConnectionDelegate>)delegate withRequestSetup:(RequestSetupBlock)requestSetup;
+- (NSURLConnection *)connectionForPath:(NSString *)path secure:(BOOL)secure andDelegate:(nullable id<NSURLConnectionDelegate>)delegate;
+- (NSURLConnection *)connectionForPath:(NSString *)path secure:(BOOL)secure andDelegate:(nullable id<NSURLConnectionDelegate>)delegate withRequestSetup:(nullable RequestSetupBlock)requestSetup;
 
 - (NSMutableURLRequest *)requestForPath:(NSString *)path secure:(BOOL)secure;
-- (NSURLConnection *)connectionForRequest:(NSURLRequest *)request delegate:(id<NSURLConnectionDelegate>)delegate;
+- (NSURLConnection *)connectionForRequest:(NSURLRequest *)request delegate:(nullable id<NSURLConnectionDelegate>)delegate;
 
 @end
 
@@ -26,3 +28,5 @@ typedef void (^RequestSetupBlock)(NSMutableURLRequest *);
 // optional
 - (NSString *)baseURLPath;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Monads/PCKCompletionHandler.h
+++ b/Foundation/Core/Monads/PCKCompletionHandler.h
@@ -1,7 +1,9 @@
 #import <Foundation/Foundation.h>
 
 
-typedef id(^PCKCompletionHandlerBlock)(id, NSURLResponse *, NSError **);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef __nullable id(^PCKCompletionHandlerBlock)(__nullable id,  NSURLResponse * __nullable , NSError * __nullable *);
 
 @interface PCKCompletionHandler : NSObject
 
@@ -11,6 +13,8 @@ typedef id(^PCKCompletionHandlerBlock)(id, NSURLResponse *, NSError **);
 - (instancetype)compose:(PCKCompletionHandler *)completionHandler;
 - (instancetype)composeWithBlock:(PCKCompletionHandlerBlock)block;
 
-- (id)callWith:(id)value response:(NSURLResponse *)response error:(NSError *)error outError:(NSError **)outError;
+- (nullable id)callWith:(nullable id)value response:(nullable NSURLResponse *)response error:(nullable NSError *)error outError:(NSError * __nullable *)outError;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Monads/PCKErrorBlock.h
+++ b/Foundation/Core/Monads/PCKErrorBlock.h
@@ -1,16 +1,19 @@
 #import <Foundation/Foundation.h>
 #import "PCKMonad.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface PCKErrorBlock : NSObject <PCKMonad>
 
-+ (instancetype)errorWithBlock:(id (^)(id, NSError **))f;
-- (instancetype)initWithBlock:(id (^)(id, NSError **))f;
++ (instancetype)errorWithBlock:(__nullable id (^)(__nullable id, NSError * __nullable *))f;
+- (instancetype)initWithBlock:(__nullable id (^)(__nullable id, NSError * __nullable *))f;
 
 - (instancetype)compose:(PCKErrorBlock *)errorBlock;
-- (instancetype)composeWithBlock:(id (^)(id, NSError **))f;
+- (instancetype)composeWithBlock:(__nullable id (^)(__nullable id, NSError * __nullable *))f;
 
-- (id)callWithSuccess:(id)success error:(NSError **)errorRef;
-- (id)callWithFailure:(NSError *)error error:(NSError **)errorRef;
+- (nullable id)callWithSuccess:(nullable id)success error:(NSError * __nullable *)errorRef;
+- (nullable id)callWithFailure:(NSError *)error error:(NSError * __nullable *)errorRef;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Monads/PCKMaybeBlock.h
+++ b/Foundation/Core/Monads/PCKMaybeBlock.h
@@ -1,15 +1,18 @@
 #import <Foundation/Foundation.h>
 #import "PCKMonad.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface PCKMaybeBlock : NSObject <PCKMonad>
 
-+ (instancetype)maybeWithBlock:(id (^)(id))f;
-- (instancetype)initWithBlock:(id (^)(id))f;
++ (instancetype)maybeWithBlock:(__nullable id (^)(__nonnull id))f;
+- (instancetype)initWithBlock:(__nullable id (^)(__nonnull id))f;
 
 - (instancetype)compose:(PCKMaybeBlock *)maybe;
-- (instancetype)composeWithBlock:(id (^)(id))f;
+- (instancetype)composeWithBlock:(__nullable id (^)(__nonnull id))f;
 
-- (id)call:(id)somethingOrNil;
+- (nullable id)call:(nullable id)somethingOrNil;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Parsers/PCKParser.h
+++ b/Foundation/Core/Parsers/PCKParser.h
@@ -2,9 +2,13 @@
 
 @protocol PCKParserDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol PCKParser <NSObject>
 
 - (void)setDelegate:(id<PCKParserDelegate>)delegate;
 - (void)parseChunk:(NSData *)chunk;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Parsers/PCKParserDelegate.h
+++ b/Foundation/Core/Parsers/PCKParserDelegate.h
@@ -2,10 +2,14 @@
 
 @protocol PCKParser;
 
-typedef void (^PCKParserErrorBlock)(NSError *);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^PCKParserErrorBlock)(NSError * __nonnull error);
 
 @protocol PCKParserDelegate
 
 - (void)parser:(id<PCKParser>)parser didEncounterError:(NSError *)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Parsers/PCKResponseParser.h
+++ b/Foundation/Core/Parsers/PCKResponseParser.h
@@ -3,8 +3,12 @@
 
 @protocol PCKParser, PCKParserDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PCKResponseParser : NSObject<NSURLConnectionDataDelegate>
 
-- (id)initWithParser:(id<PCKParser>)parser successParserDelegate:(id<PCKParserDelegate>)successParserDelegate errorParserDelegate:(id<PCKParserDelegate>)errorParserDelegate connectionDelegate:(id<NSURLConnectionDelegate>)connectionDelegate;
+- (id)initWithParser:(id<PCKParser>)parser successParserDelegate:(id<PCKParserDelegate>)successParserDelegate errorParserDelegate:(id<PCKParserDelegate>)errorParserDelegate connectionDelegate:(nullable id<NSURLConnectionDelegate>)connectionDelegate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Parsers/PCKXMLParser.h
+++ b/Foundation/Core/Parsers/PCKXMLParser.h
@@ -9,8 +9,12 @@
 
 @protocol PCKXMLParserDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PCKXMLParser : NSObject<PCKParser>
 
 - (id)initWithDelegate:(id<PCKXMLParserDelegate>)delegate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Parsers/PCKXMLParserDelegate.h
+++ b/Foundation/Core/Parsers/PCKXMLParserDelegate.h
@@ -3,8 +3,10 @@
 
 @class PCKXMLParser;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol PCKXMLParserDelegate <PCKParserDelegate>
-- (void)parser:(PCKXMLParser *)parser didStartElement:(const char *)elementName attributeCount:(int)numAttributes attributeData:(const char**)attributes;
+- (void)parser:(PCKXMLParser *)parser didStartElement:(const char *)elementName attributeCount:(int)numAttributes attributeData:(const char * __nonnull const * __nonnull)attributes;
 - (void)parser:(PCKXMLParser *)parser didEndElement:(const char *)elementName;
 - (void)parser:(PCKXMLParser *)parser didFindCharacters:(const char *)characters;
 @end
@@ -14,8 +16,10 @@ typedef void (^PCKXMLParserDelegateBlockWithAttributes)(const char *, NSDictiona
 
 @interface PCKXMLParserDelegate : NSObject <PCKXMLParserDelegate>
 
-@property (nonatomic, copy) PCKXMLParserDelegateBlock didStartElement, didEndElement, didFindCharacters;
-@property (nonatomic, copy) PCKXMLParserDelegateBlockWithAttributes didStartElementWithAttributes;
-@property (nonatomic, copy) PCKParserErrorBlock didEncounterError;
+@property (nonatomic, copy, nullable) PCKXMLParserDelegateBlock didStartElement, didEndElement, didFindCharacters;
+@property (nonatomic, copy, nullable) PCKXMLParserDelegateBlockWithAttributes didStartElementWithAttributes;
+@property (nonatomic, copy, nullable) PCKParserErrorBlock didEncounterError;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/Core/Parsers/PCKXMLParserDelegate.m
+++ b/Foundation/Core/Parsers/PCKXMLParserDelegate.m
@@ -17,7 +17,7 @@
     [super dealloc];
 }
 
-- (void)parser:(PCKXMLParser *)parser didStartElement:(const char *)elementName attributeCount:(int)numAttributes attributeData:(const char**)attributes {
+- (void)parser:(PCKXMLParser *)parser didStartElement:(const char *)elementName attributeCount:(int)numAttributes attributeData:(const char* const *)attributes {
     if (self.didStartElementWithAttributes) {
         NSMutableDictionary * attributesDictionary = [NSMutableDictionary dictionary];
         for (int i = 0; i < (numAttributes * ATTRIBUTE_SIZE); i += ATTRIBUTE_SIZE) {

--- a/Foundation/SpecHelper/Extensions/NSURLConnection+Spec.h
+++ b/Foundation/SpecHelper/Extensions/NSURLConnection+Spec.h
@@ -2,15 +2,17 @@
 
 @class PSHKFakeHTTPURLResponse;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSURLConnection (Spec)
 
 + (NSArray *)connections;
-+ (NSURLConnection *)connectionForPath:(NSString *)path;
++ (nullable NSURLConnection *)connectionForPath:(NSString *)path;
 + (void)fetchAllPendingConnectionsSynchronouslyWithTimeout:(NSTimeInterval)timeout;
 + (void)resetAll;
 
 - (NSURLRequest *)request;
-- (id)delegate;
+- (nullable id)delegate;
 
 // Please use -receiveResponse: rather than -returnResponse:.
 - (void)returnResponse:(PSHKFakeHTTPURLResponse *)response __attribute__((deprecated));
@@ -23,6 +25,8 @@
 - (void)sendAuthenticationChallengeWithCredential:(NSURLCredential *)credential;
 
 // Perform synchronous network requests
-- (NSData *)fetchSynchronouslyWithTimeout:(NSTimeInterval)timeout;
+- (nullable NSData *)fetchSynchronouslyWithTimeout:(NSTimeInterval)timeout;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/SpecHelper/Extensions/NSURLRequest+Spec.h
+++ b/Foundation/SpecHelper/Extensions/NSURLRequest+Spec.h
@@ -1,7 +1,11 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSURLRequest (Spec)
 
-- (NSString *)HTTPBodyAsString;
+- (nullable NSString *)HTTPBodyAsString;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/SpecHelper/Extensions/NSURLRequest+Spec.m
+++ b/Foundation/SpecHelper/Extensions/NSURLRequest+Spec.m
@@ -3,7 +3,8 @@
 @implementation NSURLRequest (Spec)
 
 - (NSString *)HTTPBodyAsString {
-    return [[[NSString alloc] initWithData:self.HTTPBody encoding:NSUTF8StringEncoding] autorelease];
+    NSData *body = self.HTTPBody;
+    return body ? [[[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding] autorelease] : nil;
 }
 
 @end

--- a/Foundation/SpecHelper/Extensions/NSUUID+Spec.h
+++ b/Foundation/SpecHelper/Extensions/NSUUID+Spec.h
@@ -1,6 +1,10 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSUUID (Spec)
 +(NSArray *)generatedUUIDs;
 +(void)reset;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/SpecHelper/Fakes/PSHKFakeHTTPURLResponse.h
+++ b/Foundation/SpecHelper/Fakes/PSHKFakeHTTPURLResponse.h
@@ -1,16 +1,20 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PSHKFakeHTTPURLResponse : NSHTTPURLResponse
 
-- (id)initWithStatusCode:(int)statusCode andHeaders:(NSDictionary *)headers andBody:(NSString *)body;
-- (id)initWithStatusCode:(int)statusCode andHeaders:(NSDictionary *)headers andBodyData:(NSData *)body;
+- (id)initWithStatusCode:(int)statusCode andHeaders:(nullable NSDictionary *)headers andBody:(nullable NSString *)body;
+- (id)initWithStatusCode:(int)statusCode andHeaders:(nullable NSDictionary *)headers andBodyData:(nullable NSData *)body;
 
 @property (assign, readonly) NSInteger statusCode;
 @property (copy, readonly) NSDictionary *allHeaderFields;
-@property (nonatomic, copy, readonly) NSString *body;
-@property (nonatomic, retain, readonly) NSData *bodyData;
+@property (nonatomic, copy, readonly, nullable) NSString *body;
+@property (nonatomic, retain, readonly, nullable) NSData *bodyData;
 - (NSCachedURLResponse *)asCachedResponse;
 + (PSHKFakeHTTPURLResponse *)responseFromFixtureNamed:(NSString *)fixtureName statusCode:(int)statusCode;
 + (PSHKFakeHTTPURLResponse *)responseFromFixtureNamed:(NSString *)fixtureName;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/SpecHelper/Fakes/PSHKFakeHTTPURLResponse.m
+++ b/Foundation/SpecHelper/Fakes/PSHKFakeHTTPURLResponse.m
@@ -22,7 +22,7 @@
 
     if ((self = [super initWithURL:[NSURL URLWithString:@"http://www.example.com"] MIMEType:mimeType expectedContentLength:-1 textEncodingName:nil])) {
         self.statusCode = statusCode;
-        self.allHeaderFields = headers;
+        self.allHeaderFields = headers ?: @{};
         self.bodyData = bodyData;
     }
     return self;

--- a/Foundation/SpecHelper/Fakes/PSHKFakeOperationQueue.h
+++ b/Foundation/SpecHelper/Fakes/PSHKFakeOperationQueue.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PSHKFakeOperationQueue : NSOperationQueue
 
 @property (nonatomic) BOOL runSynchronously;
@@ -8,3 +10,5 @@
 - (void)runNextOperation;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/SpecHelper/Fakes/PSHKFakeResponses.h
+++ b/Foundation/SpecHelper/Fakes/PSHKFakeResponses.h
@@ -2,6 +2,8 @@
 
 @class PSHKFakeHTTPURLResponse;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PSHKFakeResponses : NSObject {
     NSString * request_;
 }
@@ -18,3 +20,5 @@
 - (PSHKFakeHTTPURLResponse *)responseForStatusCode:(int)statusCode;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/SpecHelper/Fixtures/PSHKFixtures.h
+++ b/Foundation/SpecHelper/Fixtures/PSHKFixtures.h
@@ -1,8 +1,12 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PSHKFixtures : NSObject
 
 + (NSString *)directory;
 + (void)setDirectory:(NSString *)directory;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/SpecHelper/Helpers/PCKConnectionBlockDelegate.h
+++ b/Foundation/SpecHelper/Helpers/PCKConnectionBlockDelegate.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 
-typedef void(^PCKConnectionAsynchronousRequestBlock)(NSURLResponse*, NSData*, NSError*);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void(^PCKConnectionAsynchronousRequestBlock)(NSURLResponse* __nullable, NSData* __nullable, NSError* __nullable);
 
 @interface PCKConnectionBlockDelegate : NSObject <NSURLConnectionDataDelegate>
 
@@ -8,3 +10,5 @@ typedef void(^PCKConnectionAsynchronousRequestBlock)(NSURLResponse*, NSData*, NS
 + (PCKConnectionBlockDelegate *)delegateWithBlock:(PCKConnectionAsynchronousRequestBlock)block queue:(NSOperationQueue *)queue;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/SpecHelper/Helpers/PCKConnectionDelegateWrapper.h
+++ b/Foundation/SpecHelper/Helpers/PCKConnectionDelegateWrapper.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 
-typedef void (^PCKConnectionDelegateWrapperCompletionBlock)(NSData *);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^PCKConnectionDelegateWrapperCompletionBlock)(NSData * __nullable);
 
 @interface PCKConnectionDelegateWrapper : NSObject <NSURLConnectionDataDelegate>
 
@@ -8,3 +10,5 @@ typedef void (^PCKConnectionDelegateWrapperCompletionBlock)(NSData *);
                                     completionCallback:(PCKConnectionDelegateWrapperCompletionBlock)completionCallback;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/Core/Extensions/NSAttributedString+PivotalCoreKit_UIKit.h
+++ b/UIKit/Core/Extensions/NSAttributedString+PivotalCoreKit_UIKit.h
@@ -1,8 +1,12 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSAttributedString (PivotalCoreKit_UIKit)
 
 - (CGFloat)heightWithWidth:(CGFloat)width;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/Core/Extensions/NSString+PivotalCoreKit_UIKit.h
+++ b/UIKit/Core/Extensions/NSString+PivotalCoreKit_UIKit.h
@@ -1,8 +1,12 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSString (PivotalCoreKit_UIKit)
 
 - (CGFloat)heightWithWidth:(CGFloat)width font:(UIFont *)font;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/Core/Extensions/UIBarButtonItem+Button.h
+++ b/UIKit/Core/Extensions/UIBarButtonItem+Button.h
@@ -1,6 +1,10 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIBarButtonItem (Button)
 + (UIBarButtonItem *)barButtonItemUsingButton:(UIButton *)button;
-- (UIButton *)button;
+- (nullable UIButton *)button;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/Core/Extensions/UIImage+PivotalCore.h
+++ b/UIKit/Core/Extensions/UIImage+PivotalCore.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIImage (PivotalCore)
 
 - (CGFloat)aspectRatio;
@@ -12,3 +14,5 @@
 - (UIImage *)imageWithRoundedCorners:(CGFloat)cornerRadius;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/Core/Extensions/UIImageView+PivotalCore.h
+++ b/UIKit/Core/Extensions/UIImageView+PivotalCore.h
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIImageView (PivotalCore)
 
 + (UIImageView *)imageViewWithImageNamed:(NSString *)imageName;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/Core/Extensions/UIView+PCKNibHelpers.h
+++ b/UIKit/Core/Extensions/UIView+PCKNibHelpers.h
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIView (PCKNibHelpers)
 
 - (void)configureWithPlaceholderView:(UIView *)placeholderView;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/Core/Extensions/UIView+PivotalCore.h
+++ b/UIKit/Core/Extensions/UIView+PivotalCore.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef enum {
     ViewCornerTopLeft,
     ViewCornerBottomLeft,
@@ -20,3 +22,5 @@ typedef enum {
 - (void)resizeTo:(CGSize)size;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/UIBarButtonItem+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UIBarButtonItem+Spec.h
@@ -1,8 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface UIBarButtonItem (Spec)
 
 - (void)tap;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/UICollectionReusableView+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UICollectionReusableView+Spec.h
@@ -1,10 +1,14 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UICollectionReusableView (Spec)
 
 + (instancetype)instantiatePrototypeReusableViewFromStoryboard:(UIStoryboard *)storyboard
-                                      viewControllerIdentifier:(NSString *)viewControllerIdentifier
-                                         collectionViewKeyPath:(NSString *)collectionViewKeyPath
+                                      viewControllerIdentifier:(nullable NSString *)viewControllerIdentifier
+                                         collectionViewKeyPath:(nullable NSString *)collectionViewKeyPath
                                                 viewIdentifier:(NSString *)viewIdentifier;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/UICollectionViewCell+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UICollectionViewCell+Spec.h
@@ -1,12 +1,16 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UICollectionViewCell (Spec)
 
 - (void)tap;
 
 + (instancetype)instantiatePrototypeCellFromStoryboard:(UIStoryboard *)storyboard
-                              viewControllerIdentifier:(NSString *)viewControllerIdentifier
-                                 collectionViewKeyPath:(NSString *)collectionViewKeyPath
+                              viewControllerIdentifier:(nullable NSString *)viewControllerIdentifier
+                                 collectionViewKeyPath:(nullable NSString *)collectionViewKeyPath
                                         cellIdentifier:(NSString *)cellIdentifier;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/UIControl+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UIControl+Spec.h
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIControl (SpecHelper)
 
 - (void)tap;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/UIImage+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UIImage+Spec.h
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIImage (Spec)
 
 - (BOOL)isEqualToByBytes:(UIImage *)otherImage;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/UISegmentedControl+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UISegmentedControl+Spec.h
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UISegmentedControl (Spec)
 
 - (void)selectSegmentAtIndex:(NSInteger)index;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/UITabBarController+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UITabBarController+Spec.h
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UITabBarController (Spec)
 
 - (void)tapTabAtIndex:(NSUInteger)position;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/UITableViewCell+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UITableViewCell+Spec.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UITableViewCell (SpecHelper)
 
 - (void)tap;
@@ -7,8 +9,10 @@
 - (void)tapDeleteConfirmation;
 
 + (instancetype)instantiatePrototypeCellFromStoryboard:(UIStoryboard *)storyboard
-                              viewControllerIdentifier:(NSString *)viewControllerIdentifier
-                                      tableViewKeyPath:(NSString *)tableViewKeyPath
+                              viewControllerIdentifier:(nullable NSString *)viewControllerIdentifier
+                                      tableViewKeyPath:(nullable NSString *)tableViewKeyPath
                                         cellIdentifier:(NSString *)cellIdentifier;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/UIView+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UIView+Spec.h
@@ -1,8 +1,12 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIView (Spec)
 
-- (UIView *)subviewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier;
-- (UIView *)firstSubviewOfClass:(Class)aClass;
+- (nullable UIView *)subviewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier;
+- (nullable UIView *)firstSubviewOfClass:(Class)aClass;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/UIWindow+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UIWindow+Spec.h
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIWindow (Spec)
 
-- (UIResponder *)firstResponder;
+- (nullable UIResponder *)firstResponder;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/iOS/UISlider+Spec.h
+++ b/UIKit/SpecHelper/Extensions/iOS/UISlider+Spec.h
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UISlider (Spec)
 
 - (void)slideTo:(float)value;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Extensions/iOS/UISwitch+Spec.h
+++ b/UIKit/SpecHelper/Extensions/iOS/UISwitch+Spec.h
@@ -1,8 +1,12 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UISwitch (Spec)
 
 - (void)toggle;
 - (void)toggleToOn:(BOOL)on;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/UIActivityViewController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIActivityViewController+Spec.h
@@ -1,8 +1,12 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIActivityViewController (Spec)
 
 - (NSArray *)activityItems;
-- (NSArray *)applicationActivities;
+- (nullable NSArray *)applicationActivities;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
@@ -1,9 +1,13 @@
 #import <UIKit/UIKit.h>
 
-typedef void (^PCKAlertActionHandler)(UIAlertAction *action);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^PCKAlertActionHandler)(UIAlertAction * __nonnull action);
 
 @interface UIAlertAction (Spec)
 
-- (PCKAlertActionHandler)handler;
+- (nullable PCKAlertActionHandler)handler;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertController+Spec.h
@@ -1,8 +1,12 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIAlertController (Spec)
 
 - (void)dismissByTappingCancelButton;
 - (void)dismissByTappingButtonWithTitle:(NSString *)title;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/UIApplication+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIApplication+Spec.h
@@ -1,8 +1,12 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIApplication (Spec)
 
-+ (NSURL *)lastOpenedURL;
++ (nullable NSURL *)lastOpenedURL;
 + (void)reset;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/UIGestureRecognizer+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIGestureRecognizer+Spec.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIGestureRecognizer (Spec)
 
 - (void)recognize;
@@ -7,3 +9,5 @@
 + (void)whitelistClassForGestureSnooping:(Class)klass __attribute__((deprecated("Calling this method is no longer required")));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/UIPopoverController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIPopoverController+Spec.h
@@ -1,8 +1,12 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIPopoverController (Spec)
 
-+ (instancetype)currentPopoverController;
++ (nullable instancetype)currentPopoverController;
 + (void)reset;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.h
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PCKViewAnimation : NSObject
 
 @property (assign, nonatomic) NSTimeInterval duration;
@@ -8,7 +10,7 @@
 @property (assign, nonatomic) CGFloat initialSpringVelocity;
 @property (assign, nonatomic) UIViewAnimationOptions options;
 @property (strong, nonatomic) void (^animationBlock)(void);
-@property (strong, nonatomic) void (^completionBlock)(BOOL);
+@property (strong, nonatomic, nullable) void (^completionBlock)(BOOL);
 
 - (void)animate;
 - (void)complete;
@@ -26,6 +28,8 @@
 
 + (void)pauseAnimations;
 + (NSArray *)animations;
-+ (PCKViewAnimation *)lastAnimation;
++ (nullable PCKViewAnimation *)lastAnimation;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedGestureRecognizers.h
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedGestureRecognizers.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIView (StubbedGestureRecognizers)
 
 - (void)tap;
@@ -12,3 +14,5 @@
 #endif
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/UIViewController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIViewController+Spec.h
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIViewController (Spec)
 
 + (void)pck_useSpecStubs:(BOOL)useSpecStubs;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/iOS/UIActionSheet+Spec.h
+++ b/UIKit/SpecHelper/Stubs/iOS/UIActionSheet+Spec.h
@@ -1,18 +1,23 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIActionSheet (Spec)
 
 + (void)afterEach;
 
-+ (UIActionSheet *)currentActionSheet;
-+ (UIView *)currentActionSheetView; // might return a UIBarButtonItem
++ (nullable UIActionSheet *)currentActionSheet;
++ (nullable UIView *)currentActionSheetView; // might return a UIBarButtonItem
 
 + (void)reset;
-+ (void)setCurrentActionSheet:(UIActionSheet *)actionSheet forView:(UIView *)view;
++ (void)setCurrentActionSheet:(nullable UIActionSheet *)actionSheet forView:(nullable UIView *)view;
 
 - (NSArray *)buttonTitles;
 - (void)dismissByClickingButtonWithTitle:(NSString *)buttonTitle;
 
 - (void)dismissByClickingDestructiveButton;
 - (void)dismissByClickingCancelButton;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/iOS/UIAlertView+Spec.h
+++ b/UIKit/SpecHelper/Stubs/iOS/UIAlertView+Spec.h
@@ -1,11 +1,15 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIAlertView (Spec)
 
-+ (UIAlertView *)currentAlertView;
++ (nullable UIAlertView *)currentAlertView;
 + (void)reset;
 
 - (void)dismissWithOkButton;
 - (void)dismissWithCancelButton;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/iOS/UIImagePickerController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/iOS/UIImagePickerController+Spec.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIImagePickerController (Spec)
 
 + (void)setPhotoLibraryAvailable:(BOOL)available;
@@ -9,3 +11,5 @@
 + (BOOL)isSourceTypeAvailable:(UIImagePickerControllerSourceType)sourceType;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/iOS/UITableViewRowAction+Spec.h
+++ b/UIKit/SpecHelper/Stubs/iOS/UITableViewRowAction+Spec.h
@@ -1,9 +1,13 @@
 #import <UIKit/UIKit.h>
 
-typedef void (^PCKTableViewRowActionHandler)(UITableViewRowAction *action, NSIndexPath *indexPath);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^PCKTableViewRowActionHandler)(UITableViewRowAction * __nonnull action, NSIndexPath * __nonnull indexPath);
 
 @interface UITableViewRowAction (Spec)
 
-- (PCKTableViewRowActionHandler)handler;
+- (nullable PCKTableViewRowActionHandler)handler;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Stubs/iOS/UIWebView+Spec.h
+++ b/UIKit/SpecHelper/Stubs/iOS/UIWebView+Spec.h
@@ -1,15 +1,17 @@
 #import <UIKit/UIKit.h>
 
-typedef NSString *(^UIWebViewJavaScriptReturnBlock)();
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NSString * __nullable (^UIWebViewJavaScriptReturnBlock)();
 
 @interface UIWebView (Spec)
 
 // Loaded Requests
-- (NSString *)loadedHTMLString;
-- (NSURL *)loadedBaseURL;
-- (NSData *)loadedData;
-- (NSString *)loadedMIMEType;
-- (NSString *)loadedTextEncodingName;
+- (nullable NSString *)loadedHTMLString;
+- (nullable NSURL *)loadedBaseURL;
+- (nullable NSData *)loadedData;
+- (nullable NSString *)loadedMIMEType;
+- (nullable NSString *)loadedTextEncodingName;
 
 // Faking Requests
 - (void)sendClickRequest:(NSURLRequest *)request;
@@ -29,3 +31,5 @@ typedef NSString *(^UIWebViewJavaScriptReturnBlock)();
 - (void)disableLogging;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Support/PCKMethodRedirector.h
+++ b/UIKit/SpecHelper/Support/PCKMethodRedirector.h
@@ -1,7 +1,11 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PCKMethodRedirector : NSObject
 
 + (void)redirectSelector:(SEL)originalSelector forClass:(Class)klass to:(SEL)newSelector andRenameItTo:(SEL)renamedSelector;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UIKit/SpecHelper/Support/PCKPrototypeCellInstantiatingDataSource.h
+++ b/UIKit/SpecHelper/Support/PCKPrototypeCellInstantiatingDataSource.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PCKPrototypeCellInstantiatingDataSource : NSObject <UITableViewDataSource, UICollectionViewDataSource>
 - (instancetype)initWithTableView:(UITableView *)tableView;
 - (instancetype)initWithCollectionView:(UICollectionView *)collectionView;
@@ -12,3 +14,5 @@
 - (instancetype)initWithCollectionView:(UICollectionView *)collectionView;
 - (UICollectionReusableView *)collectionReusableViewWithIdentifier:(NSString *)viewIdentifier;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/Specs/WatchKit/WKInterfaceControllerSpec.mm
+++ b/WatchKit/Specs/WatchKit/WKInterfaceControllerSpec.mm
@@ -118,7 +118,7 @@ describe(@"WKInterfaceController", ^{
         it(@"should record the invocations of presentTextInputControllerWithSuggestions:allowedInputMode:completion:", ^{
             [subject presentTextInputControllerWithSuggestions:@[@2, @3]
                                               allowedInputMode:WKTextInputModeAllowAnimatedEmoji
-                                                    completion:nil];
+                                                    completion:^(NSArray *results){}];
             subject should have_received(@selector(presentTextInputControllerWithSuggestions:allowedInputMode:completion:)).with(@[@2, @3], WKTextInputModeAllowAnimatedEmoji, Arguments::anything);
         });
 

--- a/WatchKit/WatchKit/NSInvocation+InvocationMatching.h
+++ b/WatchKit/WatchKit/NSInvocation+InvocationMatching.h
@@ -1,7 +1,11 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSInvocation (InvocationMatching)
 
-- (BOOL)matchesTarget:(id)target selector:(SEL)selector arguments:(NSArray *)arguments;
+- (BOOL)matchesTarget:(id)target selector:(SEL)selector arguments:(nullable NSArray *)arguments;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/PCKFakeSegue.h
+++ b/WatchKit/WatchKit/PCKFakeSegue.h
@@ -7,6 +7,8 @@ typedef NS_ENUM(NSUInteger, PCKFakeSegueType) {
 };
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PCKFakeSegue : NSObject
 
 @property (nonatomic, copy, readonly) NSString *destinationIdentifier;
@@ -16,3 +18,5 @@ typedef NS_ENUM(NSUInteger, PCKFakeSegueType) {
                                          type:(PCKFakeSegueType)type;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/PCKInterfaceControllerLoader.h
+++ b/WatchKit/WatchKit/PCKInterfaceControllerLoader.h
@@ -1,20 +1,23 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface PCKInterfaceControllerLoader : NSObject
 
 - (id)interfaceControllerWithStoryboardName:(NSString *)storyboardName
                                  identifier:(NSString *)objectID
-                                     bundle:(NSBundle *)bundle;
+                                     bundle:(nullable NSBundle *)bundle;
 
-- (id)rootInterfaceControllerForStoryboardNamed:(NSString *)storyboardName inBundle:(NSBundle *)bundle;
+- (id)rootInterfaceControllerForStoryboardNamed:(NSString *)storyboardName inBundle:(nullable NSBundle *)bundle;
 
 - (id)dynamicNotificationInterfaceControllerWithStoryboardName:(NSString *)storyboardName
-                                          notificationCategory:(NSString *)notificationCategoryOrNil
-                                                        bundle:(NSBundle *)bundle;
+                                          notificationCategory:(nullable NSString *)notificationCategoryOrNil
+                                                        bundle:(nullable NSBundle *)bundle;
 
 - (id)glanceInterfaceControllerWithStoryboardName:(NSString *)storyboardName
                                        identifier:(NSString *)objectID
-                                           bundle:(NSBundle *)bundle;
+                                           bundle:(nullable NSBundle *)bundle;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/PCKInterfaceControllerLoader.m
+++ b/WatchKit/WatchKit/PCKInterfaceControllerLoader.m
@@ -60,7 +60,7 @@
                                                         bundle:(NSBundle *)bundle
 {
     NSString *processedStoryboardName = [storyboardName stringByAppendingString:@"-notification"];
-    NSString *pathForPlist = [bundle pathForResource:processedStoryboardName ofType:@"plist"];
+    NSString *pathForPlist = [(bundle ?: [NSBundle mainBundle]) pathForResource:processedStoryboardName ofType:@"plist"];
 
     if (!pathForPlist) {
         [NSException raise:NSInvalidArgumentException
@@ -81,7 +81,7 @@
                                            bundle:(NSBundle *)bundle
 {
     NSString *processedStoryboardName = [storyboardName stringByAppendingString:@"-glance"];
-    NSString *pathForPlist = [bundle pathForResource:processedStoryboardName ofType:@"plist"];
+    NSString *pathForPlist = [(bundle ?: [NSBundle mainBundle]) pathForResource:processedStoryboardName ofType:@"plist"];
 
     if (!pathForPlist) {
         [NSException raise:NSInvalidArgumentException
@@ -104,7 +104,7 @@
 #pragma mark - Private
 
 - (NSDictionary *)dictionaryForStoryboardNamed:(NSString *)storyboardName inBundle:(NSBundle *)bundle {
-    NSString *pathForPlist = [bundle pathForResource:storyboardName ofType:@"plist"];
+    NSString *pathForPlist = [(bundle ?: [NSBundle mainBundle]) pathForResource:storyboardName ofType:@"plist"];
     if (!pathForPlist) {
         [NSException raise:NSInvalidArgumentException
                     format:@"No storyboard named '%@' exists in the test target.  Did you forget to add it?", storyboardName];

--- a/WatchKit/WatchKit/PCKMessageCapturer.h
+++ b/WatchKit/WatchKit/PCKMessageCapturer.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface PCKMessageCapturer : NSObject
 
@@ -7,3 +8,5 @@
 + (NSArray *)sent_class_messages;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/PCKWKInterfaceControllerProvider.h
+++ b/WatchKit/WatchKit/PCKWKInterfaceControllerProvider.h
@@ -3,9 +3,12 @@
 
 @class WKInterfaceController;
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface PCKWKInterfaceControllerProvider : NSObject
 
 - (WKInterfaceController *)interfaceControllerWithProperties:(NSDictionary *)controllerProperties;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/PCKWKInterfaceObjectProvider.h
+++ b/WatchKit/WatchKit/PCKWKInterfaceObjectProvider.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @class WKInterfaceObject;
 @class WKInterfaceController;
@@ -11,3 +12,5 @@
                                      interfaceController:(WKInterfaceController *)interfaceController;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/UIColor+PCK_StringToColor.h
+++ b/WatchKit/WatchKit/UIColor+PCK_StringToColor.h
@@ -1,8 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface UIColor (PCK_StringToColor)
 
 + (UIColor *)colorWithNameOrHexValue:(NSString *)nameOrHexValue;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKExtension+Spec.h
+++ b/WatchKit/WatchKit/WKExtension+Spec.h
@@ -1,9 +1,13 @@
 #import <WatchKit/WatchKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface WKExtension (Spec)
 
 + (void)setSharedExtension:(WKExtension *)sharedExtension;
 
-- (void)setRootInterfaceController:(WKInterfaceController *)rootInterfaceController;
+- (void)setRootInterfaceController:(nullable WKInterfaceController *)rootInterfaceController;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceButton+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceButton+Spec.h
@@ -5,22 +5,25 @@
 @class WKInterfaceGroup;
 @class WKInterfaceController;
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceButton (Spec)
 
-- (NSString *)title;
-- (UIColor *)color;
+- (nullable NSString *)title;
+- (nullable UIColor *)color;
 - (BOOL)enabled;
-- (NSString *)action;
-- (PCKFakeSegue *)segue;
-- (WKInterfaceGroup *)content;
+- (nullable NSString *)action;
+- (nullable PCKFakeSegue *)segue;
+- (nullable WKInterfaceGroup *)content;
 
 @end
 
 @interface WKInterfaceButton (Spec2)
 
-@property (nonatomic, weak) WKInterfaceController *controller;
+@property (nonatomic, weak, nullable) WKInterfaceController *controller;
 
 - (void)triggerNonSegueAction;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceButton.h
+++ b/WatchKit/WatchKit/WKInterfaceButton.h
@@ -1,16 +1,19 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceButton : WKInterfaceObject
 
-- (void)setTitle:(NSString *)title;
-- (void)setAttributedTitle:(NSAttributedString *)attributedTitle;
+- (void)setTitle:(nullable NSString *)title;
+- (void)setAttributedTitle:(nullable NSAttributedString *)attributedTitle;
 
-- (void)setColor:(UIColor *)color;
-- (void)setBackgroundImage:(UIImage *)image;
-- (void)setBackgroundImageData:(NSData *)imageData;
-- (void)setBackgroundImageNamed:(NSString *)imageName;
+- (void)setColor:(nullable UIColor *)color;
+- (void)setBackgroundImage:(nullable UIImage *)image;
+- (void)setBackgroundImageData:(nullable NSData *)imageData;
+- (void)setBackgroundImageNamed:(nullable NSString *)imageName;
 
 - (void)setEnabled:(BOOL)enabled;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceController.h
+++ b/WatchKit/WatchKit/WKInterfaceController.h
@@ -1,5 +1,7 @@
 #import "PCKMessageCapturer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSInteger, WKUserNotificationInterfaceType)  {
     WKUserNotificationInterfaceTypeDefault,
     WKUserNotificationInterfaceTypeCustom,
@@ -42,52 +44,52 @@ typedef NS_ENUM(NSInteger, WKAlertControllerStyle) {
 
 @interface WKInterfaceController : PCKMessageCapturer
 
-- (void)awakeWithContext:(id)context;
+- (void)awakeWithContext:(nullable id)context;
 
 - (void)willActivate;
 - (void)didDeactivate;
 
 - (void)table:(WKInterfaceTable *)table didSelectRowAtIndex:(NSInteger)rowIndex;
-- (void)handleActionWithIdentifier:(NSString *)identifier
+- (void)handleActionWithIdentifier:(nullable NSString *)identifier
              forRemoteNotification:(NSDictionary *)remoteNotification;
-- (void)handleActionWithIdentifier:(NSString *)identifier
+- (void)handleActionWithIdentifier:(nullable NSString *)identifier
               forLocalNotification:(UILocalNotification *)localNotification;
-- (void)handleUserActivity:(NSDictionary *)userInfo;
+- (void)handleUserActivity:(nullable NSDictionary *)userInfo;
 
 - (void)setTitle:(NSString *)title;
 
-- (void)pushControllerWithName:(NSString *)name context:(id)context;
+- (void)pushControllerWithName:(NSString *)name context:(nullable id)context;
 - (void)popController;
 - (void)popToRootController;
 
-+ (void)reloadRootControllersWithNames:(NSArray *)names contexts:(NSArray *)contexts;
++ (void)reloadRootControllersWithNames:(NSArray<NSString *> *)names contexts:(nullable NSArray *)contexts;
 - (void)becomeCurrentPage;
 
-- (void)presentControllerWithName:(NSString *)name context:(id)context;
-- (void)presentControllerWithNames:(NSArray *)names contexts:(NSArray *)contexts;
+- (void)presentControllerWithName:(NSString *)name context:(nullable id)context;
+- (void)presentControllerWithNames:(NSArray<NSString *> *)names contexts:(nullable NSArray *)contexts;
 - (void)dismissController;
 
-- (void)presentTextInputControllerWithSuggestions:(NSArray *)suggestions
+- (void)presentTextInputControllerWithSuggestions:(nullable NSArray<NSString *> *)suggestions
                                  allowedInputMode:(WKTextInputMode)inputMode
-                                       completion:(void(^)(NSArray *results))completion;
+                                       completion:(void(^)(NSArray * __nullable results))completion;
 - (void)dismissTextInputController;
 
-- (id)contextForSegueWithIdentifier:(NSString *)segueIdentifier;
-- (NSArray *)contextsForSegueWithIdentifier:(NSString *)segueIdentifier;
-- (id)contextForSegueWithIdentifier:(NSString *)segueIdentifier inTable:(WKInterfaceTable *)table rowIndex:(NSInteger)rowIndex;
-- (NSArray *)contextsForSegueWithIdentifier:(NSString *)segueIdentifier inTable:(WKInterfaceTable *)table rowIndex:(NSInteger)rowIndex;
+- (nullable id)contextForSegueWithIdentifier:(NSString *)segueIdentifier;
+- (nullable NSArray *)contextsForSegueWithIdentifier:(NSString *)segueIdentifier;
+- (nullable id)contextForSegueWithIdentifier:(NSString *)segueIdentifier inTable:(WKInterfaceTable *)table rowIndex:(NSInteger)rowIndex;
+- (nullable NSArray *)contextsForSegueWithIdentifier:(NSString *)segueIdentifier inTable:(WKInterfaceTable *)table rowIndex:(NSInteger)rowIndex;
 
 - (void)addMenuItemWithImage:(UIImage *)image title:(NSString *)title action:(SEL)action;
 - (void)addMenuItemWithImageNamed:(NSString *)imageName title:(NSString *)title action:(SEL)action;
 - (void)addMenuItemWithItemIcon:(WKMenuItemIcon)itemIcon title:(NSString *)title action:(SEL)action;
 - (void)clearAllMenuItems;
 
-- (void)presentAlertControllerWithTitle:(NSString *)title message:(NSString *)message preferredStyle:(WKAlertControllerStyle)preferredStyle actions:(NSArray <WKAlertAction *>*)actions;
+- (void)presentAlertControllerWithTitle:(nullable NSString *)title message:(nullable NSString *)message preferredStyle:(WKAlertControllerStyle)preferredStyle actions:(NSArray <WKAlertAction *>*)actions;
 
-- (void)updateUserActivity:(NSString *)type userInfo:(NSDictionary *)userInfo;
-- (void)updateUserActivity:(NSString *)type userInfo:(NSDictionary *)userInfo webpageURL:(NSURL *)webpageURL;
+- (void)updateUserActivity:(NSString *)type userInfo:(nullable NSDictionary *)userInfo;
+- (void)updateUserActivity:(NSString *)type userInfo:(nullable NSDictionary *)userInfo webpageURL:(nullable NSURL *)webpageURL;
 
-+ (BOOL)openParentApplication:(NSDictionary *)userInfo reply:(void(^)(NSDictionary *replyInfo, NSError *error)) reply;
++ (BOOL)openParentApplication:(NSDictionary *)userInfo reply:(nullable void(^)(NSDictionary *replyInfo, NSError * __nullable error)) reply;
 
 @end
 
@@ -100,3 +102,5 @@ typedef NS_ENUM(NSInteger, WKAlertControllerStyle) {
                      withCompletion:(void(^)(WKUserNotificationInterfaceType interface)) completionHandler;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceDate+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceDate+Spec.h
@@ -1,9 +1,12 @@
 #import "WKInterfaceDate.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceDate (Spec)
 
-- (UIColor *)textColor;
-- (NSString *)format;
+- (nullable UIColor *)textColor;
+- (nullable NSString *)format;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceDate.h
+++ b/WatchKit/WatchKit/WKInterfaceDate.h
@@ -1,10 +1,14 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface WKInterfaceDate : WKInterfaceObject
 
-- (void)setTextColor:(UIColor *)color;
+- (void)setTextColor:(nullable UIColor *)color;
 
-- (void)setTimeZone:(NSTimeZone *)timeZone;
-- (void)setCalendar:(NSCalendar *)calendar;
+- (void)setTimeZone:(nullable NSTimeZone *)timeZone;
+- (void)setCalendar:(nullable NSCalendar *)calendar;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceDevice.h
+++ b/WatchKit/WatchKit/WKInterfaceDevice.h
@@ -2,6 +2,8 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import "PCKMessageCapturer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class UIImage;
 
 typedef NS_ENUM(NSInteger, WKHapticType) {
@@ -33,3 +35,5 @@ typedef NS_ENUM(NSInteger, WKHapticType) {
 - (void)playHaptic:(WKHapticType)type;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceGroup+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceGroup+Spec.h
@@ -1,8 +1,11 @@
 #import "WKInterfaceGroup.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceGroup (Spec)
 
 - (NSArray *)items;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceGroup.h
+++ b/WatchKit/WatchKit/WKInterfaceGroup.h
@@ -1,14 +1,15 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceGroup : WKInterfaceObject
 
 - (void)setCornerRadius:(CGFloat)cornerRadius;
 
-- (void)setBackgroundColor:(UIColor *)backgroundColor;
-- (void)setBackgroundImage:(UIImage *)image;
-- (void)setBackgroundImageData:(NSData *)imageData;
-- (void)setBackgroundImageNamed:(NSString *)imageName;
+- (void)setBackgroundColor:(nullable UIColor *)backgroundColor;
+- (void)setBackgroundImage:(nullable UIImage *)image;
+- (void)setBackgroundImageData:(nullable NSData *)imageData;
+- (void)setBackgroundImageNamed:(nullable NSString *)imageName;
 
 - (void)startAnimating;
 - (void)startAnimatingWithImagesInRange:(NSRange)imageRange
@@ -17,3 +18,5 @@
 - (void)stopAnimating;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceImage+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceImage+Spec.h
@@ -1,8 +1,11 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceImage (Spec)
 
-- (UIImage *)image;
+- (nullable UIImage *)image;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceImage.h
+++ b/WatchKit/WatchKit/WKInterfaceImage.h
@@ -1,13 +1,14 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceImage : WKInterfaceObject
 
-- (void)setImage:(UIImage *)image;
-- (void)setImageData:(NSData *)imageData;
-- (void)setImageNamed:(NSString *)imageName;
+- (void)setImage:(nullable UIImage *)image;
+- (void)setImageData:(nullable NSData *)imageData;
+- (void)setImageNamed:(nullable NSString *)imageName;
 
-- (void)setTintColor:(UIColor *)tintColor;
+- (void)setTintColor:(nullable UIColor *)tintColor;
 
 - (void)startAnimating;
 
@@ -17,3 +18,5 @@
 - (void)stopAnimating;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceLabel+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceLabel+Spec.h
@@ -1,9 +1,13 @@
 #import "WKInterfaceLabel.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface WKInterfaceLabel (Spec)
 
-- (NSString *)text;
-- (UIColor *)textColor;
-- (NSAttributedString *)attributedText;
+- (nullable NSString *)text;
+- (nullable UIColor *)textColor;
+- (nullable NSAttributedString *)attributedText;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceLabel.h
+++ b/WatchKit/WatchKit/WKInterfaceLabel.h
@@ -1,11 +1,14 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceLabel : WKInterfaceObject
 
-- (void)setText:(NSString *)text;
-- (void)setTextColor:(UIColor *)textColor;
+- (void)setText:(nullable NSString *)text;
+- (void)setTextColor:(nullable UIColor *)textColor;
 
-- (void)setAttributedText:(NSAttributedString *)attributedText;
+- (void)setAttributedText:(nullable NSAttributedString *)attributedText;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceMap.h
+++ b/WatchKit/WatchKit/WKInterfaceMap.h
@@ -1,6 +1,7 @@
 #import <MapKit/MapKit.h>
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 typedef enum WKInterfaceMapPinColor : NSInteger {
     WKInterfaceMapPinColorRed,
@@ -15,13 +16,15 @@ typedef enum WKInterfaceMapPinColor : NSInteger {
 - (void)setRegion:(MKCoordinateRegion)coordinateRegion;
 
 - (void)addAnnotation:(CLLocationCoordinate2D)location
-            withImage:(UIImage *)image
+            withImage:(nullable UIImage *)image
          centerOffset:(CGPoint)offset;
 - (void)addAnnotation:(CLLocationCoordinate2D)location
-       withImageNamed:(NSString *)name
+       withImageNamed:(nullable NSString *)name
          centerOffset:(CGPoint)offset;
 - (void)addAnnotation:(CLLocationCoordinate2D)location withPinColor:(WKInterfaceMapPinColor)pinColor;
 
 - (void)removeAllAnnotations;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceObject+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceObject+Spec.h
@@ -1,5 +1,6 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceObject (Spec)
 
@@ -10,3 +11,5 @@
 - (CGFloat)height;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceObject.h
+++ b/WatchKit/WatchKit/WKInterfaceObject.h
@@ -1,5 +1,6 @@
 #import "PCKMessageCapturer.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceObject : PCKMessageCapturer
 
@@ -10,3 +11,5 @@
 - (void)setHeight:(CGFloat)height;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceSeparator+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceSeparator+Spec.h
@@ -1,8 +1,11 @@
 #import "WKInterfaceSeparator.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceSeparator (Spec)
 
-- (UIColor *)color;
+- (nullable UIColor *)color;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceSeparator.h
+++ b/WatchKit/WatchKit/WKInterfaceSeparator.h
@@ -1,8 +1,11 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceSeparator : WKInterfaceObject
 
-- (void)setColor:(UIColor *)color;
+- (void)setColor:(nullable UIColor *)color;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceSlider+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceSlider+Spec.h
@@ -1,5 +1,6 @@
 #import "WKInterfaceSlider.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceSlider (Spec)
 
@@ -8,8 +9,10 @@
 - (float)minimum;
 - (float)maximum;
 - (NSInteger)numberOfSteps;
-- (UIImage *)minimumImage;
-- (UIImage *)maximumImage;
+- (nullable UIImage *)minimumImage;
+- (nullable UIImage *)maximumImage;
 - (BOOL)continuous;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceSlider.h
+++ b/WatchKit/WatchKit/WKInterfaceSlider.h
@@ -1,11 +1,14 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceSlider : WKInterfaceObject
 
 - (void)setEnabled:(BOOL)enabled;
 - (void)setValue:(float)value;
-- (void)setColor:(UIColor *)color;
+- (void)setColor:(nullable UIColor *)color;
 - (void)setNumberOfSteps:(NSInteger)numberOfSteps;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceSwitch+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceSwitch+Spec.h
@@ -1,5 +1,6 @@
 #import "WKInterfaceSwitch.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceSwitch (Spec)
 
@@ -7,3 +8,5 @@
 - (BOOL)on;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceSwitch.h
+++ b/WatchKit/WatchKit/WKInterfaceSwitch.h
@@ -1,5 +1,6 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceSwitch : WKInterfaceObject
 
@@ -7,3 +8,5 @@
 - (void)setOn:(BOOL)on;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceTable+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceTable+Spec.h
@@ -1,8 +1,11 @@
 #import "WKInterfaceTable.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceTable (Spec)
 
 - (void)stubRowController:(id)rowController atIndex:(NSUInteger)index;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceTable.h
+++ b/WatchKit/WatchKit/WKInterfaceTable.h
@@ -1,9 +1,10 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceTable : WKInterfaceObject
 
-- (void)setRowTypes:(NSArray *)rowTypes;
+- (void)setRowTypes:(NSArray<NSString *> *)rowTypes;
 - (void)setNumberOfRows:(NSInteger)numberOfRows withRowType:(NSString *)rowType;
 
 @property(nonatomic,readonly) NSInteger numberOfRows;
@@ -15,3 +16,5 @@
 - (void)scrollToRowAtIndex:(NSInteger)index;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceTimer+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceTimer+Spec.h
@@ -1,5 +1,6 @@
 #import "WKInterfaceTimer.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceTimer (Spec)
 
@@ -8,3 +9,5 @@
 - (NSUInteger)units;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKInterfaceTimer.h
+++ b/WatchKit/WatchKit/WKInterfaceTimer.h
@@ -1,12 +1,15 @@
 #import "WKInterfaceObject.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface WKInterfaceTimer : WKInterfaceObject
 
-- (void)setTextColor:(UIColor *)color;
+- (void)setTextColor:(nullable UIColor *)color;
 
 - (void)setDate:(NSDate *)date;
 - (void)start;
 - (void)stop;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WatchKit/WatchKit/WKUserNotificationInterfaceController+Spec.h
+++ b/WatchKit/WatchKit/WKUserNotificationInterfaceController+Spec.h
@@ -1,7 +1,11 @@
 #import "WKInterfaceController.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface WKUserNotificationInterfaceController (Spec)
 
-- (void(^)(WKUserNotificationInterfaceType))lastCompletionBlock;
+- (nullable void(^)(WKUserNotificationInterfaceType))lastCompletionBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
I've taken a pass at adding the appropriate nullability annotations to all the user-facing headers. Hopefully this will make things a bit smoother for folks trying to use PCK with Swift.

It's worth noting that this _does_ break compatibility with Xcode <6.3, which includes the version available on the default Travis image that we are running against. We may want to hold off on merging this until someone is able to spend some time modernizing our Travis configuration.
