### PR TITLE
-tap should raise when the control has no width or height

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -12,6 +12,7 @@
   * Adds ability to toggle UIViewController spec stubs
   * Adds support for inspecting data loaded directly into UIWebViews
   * Adds support for resetting messages sent to WatchKit interface elements.
+  * `-tap` will raise an exception if the control's width or height is zero.
 
 ## 0.3.0
 

--- a/UIKit/Spec/Extensions/UIBarButtonItemSpec+Spec.mm
+++ b/UIKit/Spec/Extensions/UIBarButtonItemSpec+Spec.mm
@@ -46,6 +46,8 @@ describe(@"UIBarButtonItemSpec_Spec", ^{
 #endif
 
         UIButton *button = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+        button.frame = CGRectMake(0, 0, 1, 1);
+
         [button addTarget:target
                    action:@selector(hello)
          forControlEvents:event];

--- a/UIKit/Spec/Extensions/UIControlSpec+Spec.mm
+++ b/UIKit/Spec/Extensions/UIControlSpec+Spec.mm
@@ -31,9 +31,10 @@ describe(@"UIControlSpec", ^{
         beforeEach(^{
             button.hidden = NO;
             button.enabled = YES;
+            button.bounds = CGRectMake(0, 0, 100, 100);
         });
 
-        context(@"when visible and enabled", ^{
+        context(@"when visible, enabled, and non-zero size", ^{
             it(@"should send control actions", ^{
                 [button tap];
                 target should have_received(@selector(hello));
@@ -68,6 +69,44 @@ describe(@"UIControlSpec", ^{
                 ^{
                     [button tap];
                 } should raise_exception.with_reason(@"Can't tap an invisible control");
+            });
+
+            it(@"should not send control actions", ^{
+                @try {
+                    [button tap];
+                } @catch(NSException *e) { }
+                target should_not have_received(@selector(hello));
+            });
+        });
+
+        context(@"when its width is zero", ^{
+            beforeEach(^{
+                button.frame = CGRectMake(0, 0, 0, 100);
+            });
+
+            it(@"should cause a spec failure", ^{
+                ^{
+                    [button tap];
+                } should raise_exception.with_reason(@"Can't tap a control with no width or height. Your control may not be laid out correctly.");
+            });
+
+            it(@"should not send control actions", ^{
+                @try {
+                    [button tap];
+                } @catch(NSException *e) { }
+                target should_not have_received(@selector(hello));
+            });
+        });
+
+        context(@"when its height is zero", ^{
+            beforeEach(^{
+                button.frame = CGRectMake(0, 0, 100, 0);
+            });
+
+            it(@"should cause a spec failure", ^{
+                ^{
+                    [button tap];
+                } should raise_exception.with_reason(@"Can't tap a control with no width or height. Your control may not be laid out correctly.");
             });
 
             it(@"should not send control actions", ^{

--- a/UIKit/SpecHelper/Extensions/UIControl+Spec.m
+++ b/UIKit/SpecHelper/Extensions/UIControl+Spec.m
@@ -1,13 +1,21 @@
 #import "UIControl+Spec.h"
 
+static NSString *exceptionName = @"Untappable";
+static NSString *hiddenExceptionReason = @"Can't tap an invisible control";
+static NSString *disabledExceptionReason = @"Can't tap a disabled control";
+static NSString *zeroSizeExceptionReason = @"Can't tap a control with no width or height. Your control may not be laid out correctly.";
+
 @implementation UIControl (Spec)
 
 - (void)tap {
     if (self.hidden) {
-        [[NSException exceptionWithName:@"Untappable" reason:@"Can't tap an invisible control" userInfo:nil] raise];
+        [[NSException exceptionWithName:exceptionName reason:hiddenExceptionReason userInfo:nil] raise];
     }
     if (!self.isEnabled) {
-        [[NSException exceptionWithName:@"Untappable" reason:@"Can't tap a disabled control" userInfo:nil] raise];
+        [[NSException exceptionWithName:exceptionName reason:disabledExceptionReason userInfo:nil] raise];
+    }
+    if (self.bounds.size.width == 0 || self.bounds.size.height == 0) {
+        [[NSException exceptionWithName:exceptionName reason:zeroSizeExceptionReason userInfo:nil] raise];
     }
     [self sendActionsForControlEvents:UIControlEventTouchUpInside];
 }


### PR DESCRIPTION
Encountered this on a project today. It felt very strange that PCK would allow
you to tap on controls that wouldn't be able to receive touch events in a real
setting. This sparked a discussion around "should we be using -clipsToBounds=Yes ?"
but decided that improving PCK to catch these errors earlier would be better.

For reference, the problem we needed to fix had to do with autolayout. We had forgot
to set some autolayout constraints correctly and ended up with a zero width, zero height
control that, while it looked okay, wasn't tappable.