### PR TITLE
UITableViewCell -tap should raise outside a tableview

### DIFF
--- a/UIKit/Spec/Extensions/UITableViewCellSpec+Spec.mm
+++ b/UIKit/Spec/Extensions/UITableViewCellSpec+Spec.mm
@@ -13,35 +13,6 @@
 @property (nonatomic, retain) NSIndexPath *lastSelectedIndexPath;
 @end
 
-@implementation SpecTableViewController
-
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:@"Cell"];
-}
-
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return 2;
-}
-
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    return [tableView dequeueReusableCellWithIdentifier:@"Cell"];
-}
-
-- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
-    return;
-}
-
-- (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
-    return self.shouldHighlightRows;
-}
-
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    self.lastSelectedIndexPath = indexPath;
-}
-
-@end
-
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
 
@@ -165,6 +136,10 @@ describe(@"UITableViewCell+Spec", ^{
                 controller.presentedViewController should_not be_nil;
             });
         });
+
+        it(@"raises when tapped outside of a tableview", ^{
+            ^{ [[[UITableViewCell alloc] init] tap]; } should raise_exception;
+        });
     });
 
     describe(@"-tapDeleteAccessory", ^{
@@ -277,3 +252,34 @@ describe(@"UITableViewCell+Spec", ^{
 });
 
 SPEC_END
+
+#pragma mark - Spec Helpers
+
+@implementation SpecTableViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:@"Cell"];
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return 2;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    return [tableView dequeueReusableCellWithIdentifier:@"Cell"];
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+    return;
+}
+
+- (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
+    return self.shouldHighlightRows;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    self.lastSelectedIndexPath = indexPath;
+}
+
+@end

--- a/UIKit/SpecHelper/Extensions/UITableViewCell+Spec.m
+++ b/UIKit/SpecHelper/Extensions/UITableViewCell+Spec.m
@@ -22,13 +22,14 @@
 @implementation UITableViewCell (Spec)
 
 - (void)tap {
-    UIView *currentView = self;
-    while (currentView.superview != nil && ![currentView isKindOfClass:[UITableView class]]) {
-        currentView = currentView.superview;
+    UITableView *tableView = [self containingTableViewOrNil];
+
+    if (!tableView) {
+        [[NSException exceptionWithName:@"Untappable"
+                                 reason:@"Cell must be in a table view in order to be tapped!"
+                               userInfo:nil] raise];
     }
 
-    NSAssert(currentView, @"Cell must be in a table view in order to be tapped!");
-    UITableView *tableView = (UITableView *)currentView;
     [tableView layoutIfNeeded];
     NSIndexPath *indexPath = [tableView indexPathForCell:self];
 
@@ -124,6 +125,21 @@
     PCKPrototypeCellInstantiatingDataSource *dataSource = [[[PCKPrototypeCellInstantiatingDataSource alloc] initWithTableView:tableView] autorelease];
     return [dataSource tableViewCellWithIdentifier:cellIdentifier];
 
+}
+
+#pragma mark - Private
+
+- (UITableView *)containingTableViewOrNil {
+    UIView *currentView = self;
+    while (currentView != nil) {
+        if ([currentView isKindOfClass:[UITableView class]]) {
+            return (UITableView *)currentView;
+        }
+
+        currentView = currentView.superview;
+    }
+
+    return nil;
 }
 
 @end


### PR DESCRIPTION
Makes this more consistent with the UIControl -tap behavior.

We ran across this on my project last week and were really surprised
that the resultant error was not the assertion, but rather the runtime
complaining that UITableViewCell does not recognize the selector
"layoutIfNeeded".