### PR TITLE
Fix UIActionSheet/UIAlertView deprecation warnings

### DIFF
--- a/CoreLocation/CoreLocation.xcodeproj/xcshareddata/xcschemes/CoreLocation+PivotalSpecHelper-iOS.xcscheme
+++ b/CoreLocation/CoreLocation.xcodeproj/xcshareddata/xcschemes/CoreLocation+PivotalSpecHelper-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CoreLocation/CoreLocation.xcodeproj/xcshareddata/xcschemes/CoreLocation+PivotalSpecHelper-tvOS.xcscheme
+++ b/CoreLocation/CoreLocation.xcodeproj/xcshareddata/xcschemes/CoreLocation+PivotalSpecHelper-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CoreLocation/CoreLocation.xcodeproj/xcshareddata/xcschemes/CoreLocation+PivotalSpecHelper-watchOS.xcscheme
+++ b/CoreLocation/CoreLocation.xcodeproj/xcshareddata/xcschemes/CoreLocation+PivotalSpecHelper-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CoreLocation/CoreLocation.xcodeproj/xcshareddata/xcschemes/CoreLocation+PivotalSpecHelper.xcscheme
+++ b/CoreLocation/CoreLocation.xcodeproj/xcshareddata/xcschemes/CoreLocation+PivotalSpecHelper.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CoreLocation/CoreLocation.xcodeproj/xcshareddata/xcschemes/CoreLocation-StaticLibSpec.xcscheme
+++ b/CoreLocation/CoreLocation.xcodeproj/xcshareddata/xcschemes/CoreLocation-StaticLibSpec.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalCore-iOS.xcscheme
+++ b/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalCore-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalCore-tvOS.xcscheme
+++ b/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalCore-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalCore-watchOS.xcscheme
+++ b/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalCore-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalCore.xcscheme
+++ b/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalSpecHelper-iOS.xcscheme
+++ b/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalSpecHelper-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalSpecHelper-tvOS.xcscheme
+++ b/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalSpecHelper-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalSpecHelper-watchOS.xcscheme
+++ b/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalSpecHelper-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalSpecHelper.xcscheme
+++ b/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation+PivotalSpecHelper.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation-StaticLibSpec.xcscheme
+++ b/Foundation/Foundation.xcodeproj/xcshareddata/xcschemes/Foundation-StaticLibSpec.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UIKit/SpecHelper/Stubs/iOS/UIActionSheet+Spec.m
+++ b/UIKit/SpecHelper/Stubs/iOS/UIActionSheet+Spec.m
@@ -4,6 +4,8 @@
 
 #import "UIActionSheet+Spec.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 @implementation UIActionSheet (Spec)
 
@@ -99,3 +101,5 @@ static UIView *currentActionSheetView__;
 }
 
 @end
+
+#pragma clang diagnostic pop

--- a/UIKit/SpecHelper/Stubs/iOS/UIAlertView+Spec.m
+++ b/UIKit/SpecHelper/Stubs/iOS/UIAlertView+Spec.m
@@ -4,6 +4,8 @@
 
 #import "UIAlertView+Spec.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 @implementation UIAlertView (Spec)
 
@@ -53,7 +55,7 @@ static NSMutableArray *alertViewStack__ = nil;
     }
     [alertViewStack__ removeObject:self];
 }
-#pragma clang diagnostic pop
+#pragma clang diagnostic pop // "-Wobjc-protocol-method-implementation"
 
 - (void)dismissWithOkButton {
     [self dismissWithClickedButtonIndex:self.firstOtherButtonIndex animated:NO];
@@ -64,3 +66,5 @@ static NSMutableArray *alertViewStack__ = nil;
 }
 
 @end
+
+#pragma clang diagnostic pop // "-Wdeprecated-declarations"

--- a/UIKit/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit/UIKit.xcodeproj/project.pbxproj
@@ -1774,7 +1774,7 @@
 		AEBCCBA7168B95A00056EE83 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Pivotal Labs";
 				TargetAttributes = {
 					3466C0931B97A3C500CBAB59 = {

--- a/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalCore-iOS.xcscheme
+++ b/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalCore-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalCore-tvOS.xcscheme
+++ b/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalCore-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalSpecHelper-iOS.xcscheme
+++ b/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalSpecHelper-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalSpecHelper-tvOS.xcscheme
+++ b/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalSpecHelper-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalSpecHelperStubs-iOS.xcscheme
+++ b/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalSpecHelperStubs-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalSpecHelperStubs-tvOS.xcscheme
+++ b/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit+PivotalSpecHelperStubs-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit-StaticLibSpec.xcscheme
+++ b/UIKit/UIKit.xcodeproj/xcshareddata/xcschemes/UIKit-StaticLibSpec.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WatchKit/WatchKit.xcodeproj/xcshareddata/xcschemes/WatchKit.xcscheme
+++ b/WatchKit/WatchKit.xcodeproj/xcshareddata/xcschemes/WatchKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
These warnings show up when integrating PCK as a CocoaPod in a project with a deployment target of iOS 9.0