### PR TITLE
Convert getter-like methods into readonly properties

### DIFF
--- a/CoreLocation/SpecHelper/Extensions/CLGeocoder+Spec.h
+++ b/CoreLocation/SpecHelper/Extensions/CLGeocoder+Spec.h
@@ -2,8 +2,8 @@
 
 @interface CLGeocoder (Spec)
 
-- (NSString *)addressString;
-- (CLLocation *)location;
+@property (nonatomic, readonly) NSString *addressString;
+@property (nonatomic, readonly) CLLocation *location;
 
 - (void)completeGeocodeWithPlacemarks:(NSArray *)placemarks;
 - (void)completeReverseGeocodeWithPlacemarks:(NSArray *)placemarks;

--- a/Foundation/Core/Extensions/NSData+PivotalCore.h
+++ b/Foundation/Core/Extensions/NSData+PivotalCore.h
@@ -4,5 +4,6 @@
 + (id)dataWithSHA1HashOfString:(NSString *)string;
 - (id)initWithSHA1HashOfString:(NSString *)string;
 
-- (NSString *)hexadecimalString;
+@property (nonatomic, readonly) NSString *hexadecimalString;
+
 @end

--- a/Foundation/Core/Extensions/NSString+PivotalCore.h
+++ b/Foundation/Core/Extensions/NSString+PivotalCore.h
@@ -7,9 +7,9 @@
 + (id)stringWithBase64EncodedData:(NSData *)data DEPRECATED_ATTRIBUTE;
 - (id)initWithBase64EncodedData:(NSData *)data DEPRECATED_ATTRIBUTE;
 
-- (NSString *)stringByCamelizing;
-- (BOOL)isBlank;
-- (BOOL)isValidEmailAddress;
+@property (nonatomic, readonly) NSString *stringByCamelizing;
+@property (nonatomic, readonly) BOOL isBlank;
+@property (nonatomic, readonly) BOOL isValidEmailAddress;
 
 /*
  Overrides the framework version of stringbyAddingPercentEscapesUsingEncoding,

--- a/Foundation/Core/Extensions/NSURL+QueryComponents.h
+++ b/Foundation/Core/Extensions/NSURL+QueryComponents.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
 
 @interface NSURL (QueryComponents)
--(NSDictionary *)queryComponents;
+@property (nonatomic, readonly) NSDictionary *queryComponents;
 @end

--- a/Foundation/Core/Interfaces/PCKHTTPInterface.h
+++ b/Foundation/Core/Interfaces/PCKHTTPInterface.h
@@ -22,7 +22,7 @@ typedef void (^RequestSetupBlock)(NSMutableURLRequest *);
 
 @interface PCKHTTPInterface (SubclassDelegation)
 // required
-- (NSString *)host;
+@property (nonatomic, readonly) NSString *host;
 // optional
-- (NSString *)baseURLPath;
+@property (nonatomic, readonly) NSString *baseURLPath;
 @end

--- a/Foundation/SpecHelper/Extensions/NSURLConnection+Spec.h
+++ b/Foundation/SpecHelper/Extensions/NSURLConnection+Spec.h
@@ -9,8 +9,8 @@
 + (void)fetchAllPendingConnectionsSynchronouslyWithTimeout:(NSTimeInterval)timeout;
 + (void)resetAll;
 
-- (NSURLRequest *)request;
-- (id)delegate;
+@property (nonatomic, readonly) NSURLRequest *request;
+@property (nonatomic, readonly) id delegate;
 
 // Please use -receiveResponse: rather than -returnResponse:.
 - (void)returnResponse:(PSHKFakeHTTPURLResponse *)response __attribute__((deprecated));

--- a/Foundation/SpecHelper/Extensions/NSURLRequest+Spec.h
+++ b/Foundation/SpecHelper/Extensions/NSURLRequest+Spec.h
@@ -2,6 +2,6 @@
 
 @interface NSURLRequest (Spec)
 
-- (NSString *)HTTPBodyAsString;
+@property (nonatomic, readonly) NSString *HTTPBodyAsString;
 
 @end

--- a/Foundation/SpecHelper/Fakes/PSHKFakeResponses.h
+++ b/Foundation/SpecHelper/Fakes/PSHKFakeResponses.h
@@ -9,11 +9,11 @@
 + (id)responsesForRequest:(NSString *)request;
 - (id)initForRequest:(NSString *)request;
 
-- (PSHKFakeHTTPURLResponse *)success;
-- (PSHKFakeHTTPURLResponse *)badRequest;
-- (PSHKFakeHTTPURLResponse *)authenticationFailure;
-- (PSHKFakeHTTPURLResponse *)serverError;
-- (PSHKFakeHTTPURLResponse *)conflict;
+@property (nonatomic, readonly) PSHKFakeHTTPURLResponse *success;
+@property (nonatomic, readonly) PSHKFakeHTTPURLResponse *badRequest;
+@property (nonatomic, readonly) PSHKFakeHTTPURLResponse *authenticationFailure;
+@property (nonatomic, readonly) PSHKFakeHTTPURLResponse *serverError;
+@property (nonatomic, readonly) PSHKFakeHTTPURLResponse *conflict;
 
 - (PSHKFakeHTTPURLResponse *)responseForStatusCode:(int)statusCode;
 

--- a/UIKit/Core/Extensions/UIBarButtonItem+Button.h
+++ b/UIKit/Core/Extensions/UIBarButtonItem+Button.h
@@ -2,5 +2,5 @@
 
 @interface UIBarButtonItem (Button)
 + (UIBarButtonItem *)barButtonItemUsingButton:(UIButton *)button;
-- (UIButton *)button;
+@property (nonatomic, readonly) UIButton *button;
 @end

--- a/UIKit/Core/Extensions/UIImage+PivotalCore.h
+++ b/UIKit/Core/Extensions/UIImage+PivotalCore.h
@@ -2,7 +2,7 @@
 
 @interface UIImage (PivotalCore)
 
-- (CGFloat)aspectRatio;
+@property (nonatomic, readonly) CGFloat aspectRatio;
 + (UIImage *)imageWithData:(NSData *)data scale:(CGFloat)scale;
 - (UIImage *)resizedToSize:(CGSize)newSize;
 - (UIImage *)aspectFitResizedToSize:(CGSize)newSize;

--- a/UIKit/Core/Extensions/UIView+PivotalCore.h
+++ b/UIKit/Core/Extensions/UIView+PivotalCore.h
@@ -10,7 +10,7 @@ typedef enum {
 @interface UIView (PivotalCore)
 
 // Intended for the idiom view.center = superview.centerBounds;
-- (CGPoint)centerBounds;
+@property (nonatomic, readonly)  CGPoint centerBounds;
 
 // Move/resize as separate operations, working off of all four corners
 - (void)moveCorner:(ViewCorner)corner toPoint:(CGPoint)point;

--- a/UIKit/SpecHelper/Extensions/UIWindow+Spec.h
+++ b/UIKit/SpecHelper/Extensions/UIWindow+Spec.h
@@ -2,6 +2,6 @@
 
 @interface UIWindow (Spec)
 
-- (UIResponder *)firstResponder;
+@property (nonatomic, readonly) UIResponder *firstResponder;
 
 @end

--- a/UIKit/SpecHelper/Stubs/UIActivityViewController+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIActivityViewController+Spec.h
@@ -2,7 +2,7 @@
 
 @interface UIActivityViewController (Spec)
 
-- (NSArray *)activityItems;
-- (NSArray *)applicationActivities;
+@property (nonatomic, readonly) NSArray *activityItems;
+@property (nonatomic, readonly) NSArray *applicationActivities;
 
 @end

--- a/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIAlertAction+Spec.h
@@ -4,6 +4,6 @@ typedef void (^PCKAlertActionHandler)(UIAlertAction *action);
 
 @interface UIAlertAction (Spec)
 
-- (PCKAlertActionHandler)handler;
+@property (nonatomic, readonly) PCKAlertActionHandler handler;
 
 @end

--- a/UIKit/SpecHelper/Stubs/iOS/UIActionSheet+Spec.h
+++ b/UIKit/SpecHelper/Stubs/iOS/UIActionSheet+Spec.h
@@ -10,7 +10,7 @@
 + (void)reset;
 + (void)setCurrentActionSheet:(UIActionSheet *)actionSheet forView:(UIView *)view;
 
-- (NSArray *)buttonTitles;
+@property (nonatomic, readonly) NSArray *buttonTitles;
 - (void)dismissByClickingButtonWithTitle:(NSString *)buttonTitle;
 
 - (void)dismissByClickingDestructiveButton;

--- a/UIKit/SpecHelper/Stubs/iOS/UITableViewRowAction+Spec.h
+++ b/UIKit/SpecHelper/Stubs/iOS/UITableViewRowAction+Spec.h
@@ -4,6 +4,6 @@ typedef void (^PCKTableViewRowActionHandler)(UITableViewRowAction *action, NSInd
 
 @interface UITableViewRowAction (Spec)
 
-- (PCKTableViewRowActionHandler)handler;
+@property (nonatomic, readonly) PCKTableViewRowActionHandler handler;
 
 @end

--- a/UIKit/SpecHelper/Stubs/iOS/UIWebView+Spec.h
+++ b/UIKit/SpecHelper/Stubs/iOS/UIWebView+Spec.h
@@ -5,11 +5,11 @@ typedef NSString *(^UIWebViewJavaScriptReturnBlock)();
 @interface UIWebView (Spec)
 
 // Loaded Requests
-- (NSString *)loadedHTMLString;
-- (NSURL *)loadedBaseURL;
-- (NSData *)loadedData;
-- (NSString *)loadedMIMEType;
-- (NSString *)loadedTextEncodingName;
+@property (nonatomic, readonly) NSString *loadedHTMLString;
+@property (nonatomic, readonly) NSURL *loadedBaseURL;
+@property (nonatomic, readonly) NSData *loadedData;
+@property (nonatomic, readonly) NSString *loadedMIMEType;
+@property (nonatomic, readonly) NSString *loadedTextEncodingName;
 
 // Faking Requests
 - (void)sendClickRequest:(NSURLRequest *)request;
@@ -22,7 +22,7 @@ typedef NSString *(^UIWebViewJavaScriptReturnBlock)();
 // JavaScript
 - (void)setReturnValue:(NSString *)returnValue forJavaScript:(NSString *)javaScript;
 - (void)setReturnBlock:(UIWebViewJavaScriptReturnBlock)block forJavaScript:(NSString *)javaScript;
-- (NSArray *)executedJavaScripts;
+@property (nonatomic, readonly) NSArray *executedJavaScripts;
 
 // Debugging
 - (void)enableLogging;

--- a/WatchKit/WatchKit/PCKMessageCapturer.h
+++ b/WatchKit/WatchKit/PCKMessageCapturer.h
@@ -3,7 +3,7 @@
 
 @interface PCKMessageCapturer : NSObject
 
-- (NSArray *)sent_messages;
+@property (nonatomic, readonly) NSArray *sent_messages;
 - (void)reset_sent_messages;
 
 + (NSArray *)sent_class_messages;

--- a/WatchKit/WatchKit/PCKMessageCapturer.m
+++ b/WatchKit/WatchKit/PCKMessageCapturer.m
@@ -1,14 +1,10 @@
 #import "PCKMessageCapturer.h"
 
-@interface PCKMessageCapturer ()
+@implementation PCKMessageCapturer {
+    NSMutableArray *_sent_messages;
+}
 
-@property (nonatomic) NSMutableArray *sent_messages;
-
-@end
-
-@implementation PCKMessageCapturer
-
-static  NSMutableArray *sent_class_messages_array;
+static NSMutableArray *sent_class_messages_array;
 
 #pragma mark - NSObject
 
@@ -16,7 +12,7 @@ static  NSMutableArray *sent_class_messages_array;
 {
     self = [super init];
     if (self) {
-        self.sent_messages = [NSMutableArray array];
+        _sent_messages = [NSMutableArray array];
     }
     return self;
 }

--- a/WatchKit/WatchKit/WKInterfaceButton+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceButton+Spec.h
@@ -8,12 +8,12 @@
 
 @interface WKInterfaceButton (Spec)
 
-- (NSString *)title;
-- (UIColor *)color;
-- (BOOL)enabled;
-- (NSString *)action;
-- (PCKFakeSegue *)segue;
-- (WKInterfaceGroup *)content;
+@property (nonatomic, readonly) NSString *title;
+@property (nonatomic, readonly) UIColor *color;
+@property (nonatomic, readonly) BOOL enabled;
+@property (nonatomic, readonly) NSString *action;
+@property (nonatomic, readonly) PCKFakeSegue *segue;
+@property (nonatomic, readonly) WKInterfaceGroup *content;
 
 @end
 

--- a/WatchKit/WatchKit/WKInterfaceDate+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceDate+Spec.h
@@ -3,7 +3,7 @@
 
 @interface WKInterfaceDate (Spec)
 
-- (UIColor *)textColor;
-- (NSString *)format;
+@property (nonatomic, readonly) UIColor *textColor;
+@property (nonatomic, readonly) NSString *format;
 
 @end

--- a/WatchKit/WatchKit/WKInterfaceGroup+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceGroup+Spec.h
@@ -3,6 +3,6 @@
 
 @interface WKInterfaceGroup (Spec)
 
-- (NSArray *)items;
+@property (nonatomic, readonly) NSArray *items;
 
 @end

--- a/WatchKit/WatchKit/WKInterfaceImage+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceImage+Spec.h
@@ -3,6 +3,6 @@
 
 @interface WKInterfaceImage (Spec)
 
-- (UIImage *)image;
+@property (nonatomic, readonly) UIImage *image;
 
 @end

--- a/WatchKit/WatchKit/WKInterfaceLabel+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceLabel+Spec.h
@@ -2,8 +2,8 @@
 
 @interface WKInterfaceLabel (Spec)
 
-- (NSString *)text;
-- (UIColor *)textColor;
-- (NSAttributedString *)attributedText;
+@property (nonatomic, readonly) NSString *text;
+@property (nonatomic, readonly) UIColor *textColor;
+@property (nonatomic, readonly) NSAttributedString *attributedText;
 
 @end

--- a/WatchKit/WatchKit/WKInterfaceObject+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceObject+Spec.h
@@ -3,10 +3,10 @@
 
 @interface WKInterfaceObject (Spec)
 
-- (BOOL)isHidden;
-- (CGFloat)alpha;
+@property (nonatomic, readonly) BOOL isHidden;
+@property (nonatomic, readonly) CGFloat alpha;
 
-- (CGFloat)width;
-- (CGFloat)height;
+@property (nonatomic, readonly) CGFloat width;
+@property (nonatomic, readonly) CGFloat height;
 
 @end

--- a/WatchKit/WatchKit/WKInterfaceSeparator+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceSeparator+Spec.h
@@ -3,6 +3,6 @@
 
 @interface WKInterfaceSeparator (Spec)
 
-- (UIColor *)color;
+@property (nonatomic, readonly) UIColor *color;
 
 @end

--- a/WatchKit/WatchKit/WKInterfaceSlider+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceSlider+Spec.h
@@ -3,13 +3,13 @@
 
 @interface WKInterfaceSlider (Spec)
 
-- (BOOL)enabled;
-- (float)value;
-- (float)minimum;
-- (float)maximum;
-- (NSInteger)numberOfSteps;
-- (UIImage *)minimumImage;
-- (UIImage *)maximumImage;
-- (BOOL)continuous;
+@property (nonatomic, readonly) BOOL enabled;
+@property (nonatomic, readonly) float value;
+@property (nonatomic, readonly) float minimum;
+@property (nonatomic, readonly) float maximum;
+@property (nonatomic, readonly) NSInteger numberOfSteps;
+@property (nonatomic, readonly) UIImage *minimumImage;
+@property (nonatomic, readonly) UIImage *maximumImage;
+@property (nonatomic, readonly) BOOL continuous;
 
 @end

--- a/WatchKit/WatchKit/WKInterfaceSwitch+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceSwitch+Spec.h
@@ -3,7 +3,7 @@
 
 @interface WKInterfaceSwitch (Spec)
 
-- (BOOL)enabled;
-- (BOOL)on;
+@property (nonatomic, readonly) BOOL enabled;
+@property (nonatomic, readonly) BOOL on;
 
 @end

--- a/WatchKit/WatchKit/WKInterfaceTimer+Spec.h
+++ b/WatchKit/WatchKit/WKInterfaceTimer+Spec.h
@@ -3,8 +3,8 @@
 
 @interface WKInterfaceTimer (Spec)
 
-- (BOOL)enabled;
+@property (nonatomic, readonly) BOOL enabled;
 
-- (NSUInteger)units;
+@property (nonatomic, readonly) NSUInteger units;
 
 @end

--- a/WatchKit/WatchKit/WKUserNotificationInterfaceController+Spec.h
+++ b/WatchKit/WatchKit/WKUserNotificationInterfaceController+Spec.h
@@ -2,6 +2,6 @@
 
 @interface WKUserNotificationInterfaceController (Spec)
 
-- (void(^)(WKUserNotificationInterfaceType))lastCompletionBlock;
+@property (nonatomic, readonly) void(^lastCompletionBlock)(WKUserNotificationInterfaceType);
 
 @end


### PR DESCRIPTION
This improves the Swift bridging. The methods get bridged into Swift as functions, which need to be invoked with `()` which feels un-idomatic when they are intended to effectively be getters.

This is especially problematic in cases like `tableRowAction.handler()` which (previously) would return the handler closure, but *not* actually invoke it, despite appearances.

Thanks to @pivotal-rebecca-chin for first making me aware of this issue and tracking down what was going on.