### PR TITLE
-transitionFromVC:toVC:... SpecHelper stub behaves more like UIKit

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -2,6 +2,8 @@
 
 ## 0.3.3 (in progress)
 
+  * `transitionToViewController:fromViewController...` SpecHelper stub behaves more like UIKit.
+
 ## 0.3.2
 
   * Fixes the cocoapods release. v0.3.1 was released with support for tvOS only. Sorry!

--- a/UIKit/Spec/Stubs/UIViewControllerSpec+Spec.mm
+++ b/UIKit/Spec/Stubs/UIViewControllerSpec+Spec.mm
@@ -208,13 +208,19 @@ describe(@"UIViewController (spec extensions)", ^{
         __block UIViewController *parentController;
         __block UIViewController *oldChildController;
         __block UIViewController *newChildController;
+        __block UIView *parentControllerContentView;
+
         beforeEach(^{
             parentController = [[UIViewController alloc] init];
             oldChildController = [[UIViewController alloc] init];
             newChildController = [[UIViewController alloc] init];
+            parentControllerContentView = [[UIView alloc] init];
+
+            [parentController.view addSubview:parentControllerContentView];
 
             [parentController addChildViewController:oldChildController];
-            [parentController.view addSubview:oldChildController.view];
+
+            [parentControllerContentView addSubview:oldChildController.view];
             [oldChildController didMoveToParentViewController:parentController];
 
             [parentController transitionFromViewController:oldChildController
@@ -225,8 +231,12 @@ describe(@"UIViewController (spec extensions)", ^{
                                                 completion:nil];
         });
 
-        it(@"should make the new child controller's view to the parent's view's subviews", ^{
-            parentController.view.subviews should contain(newChildController.view);
+        it(@"should add the newChildController's view to oldChildController's view's superview", ^{
+            newChildController.view.superview should equal(parentControllerContentView);
+        });
+
+        it(@"should remove the oldChildController's view from its superview", ^{
+            oldChildController.view.superview should be_nil;
         });
     });
 });

--- a/UIKit/SpecHelper/Stubs/UIViewController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIViewController+Spec.m
@@ -130,11 +130,13 @@ static char PRESENTED_CONTROLLER_KEY;
 
 - (void)pck_transitionFromViewController:(UIViewController *)fromViewController toViewController:(UIViewController *)toViewController duration:(NSTimeInterval)duration options:(UIViewAnimationOptions)options animations:(void (^)(void))animations completion:(void (^)(BOOL))completion {
 
-    [[self view] addSubview:toViewController.view];
+    [fromViewController.view.superview addSubview:toViewController.view];
 
     if (animations) {
         animations();
     }
+
+    [fromViewController.view removeFromSuperview];
 
     if (completion) {
         completion(YES);


### PR DESCRIPTION
This change makes the 'pck_transitionFromViewController' SpecHelper stub behave more like the UIKit implementation. UIKit adds the incoming viewController's view to the outgoing viewController's view's superview. It also removes the outgoing viewController's view from its superview. Now 'pck_transitionFromViewController' does too.