### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -136,7 +136,7 @@ Without PivotalCoreKit's UIWebView stubs, the webView's NSURLRequest will be nil
 ### Via CocoaPods
 
 1. Install [CocoaPods](http://cocoapods.org/) with `gem install cocoapods`.
-2. Create a file in your XCode project called `Podfile` and add the following line:
+2. Create a file in your Xcode project called `Podfile` and add the following line:
 
 ```
 pod 'PivotalCoreKit'


### PR DESCRIPTION

This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
