### PR TITLE
Removed circular references in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,7 @@ def build_and_test_scheme(scheme)
   end
 end
 
-def build_target(target, project: project, output_file: output_file, sdk: sdk)
+def build_target(target, project: nil, output_file: nil, sdk: nil)
    command = ["xcodebuild",
    "-project",
    "#{project}.xcodeproj",


### PR DESCRIPTION
Picked this one up when running the build against some never Ruby versions. Not completely sure what the original intent was?