### PR TITLE
Upgrade Cedar & conform SpecHelpers with hooks

### DIFF
--- a/Foundation/Spec/Fixtures/FixturesHelper.m
+++ b/Foundation/Spec/Fixtures/FixturesHelper.m
@@ -1,7 +1,8 @@
 #import <Foundation/Foundation.h>
 #import "PSHKFixtures.h"
+#import "CDRHooks.h"
 
-@interface FixturesHelper : NSObject; @end
+@interface FixturesHelper : NSObject<CDRHooks>; @end
 @implementation FixturesHelper
 
 + (void)beforeEach {

--- a/Foundation/SpecHelper/Extensions/NSURLConnection+Spec.m
+++ b/Foundation/SpecHelper/Extensions/NSURLConnection+Spec.m
@@ -34,6 +34,13 @@ static PSHKFakeOperationQueue *connectionsQueue__;
 
 @implementation NSURLConnection (Spec)
 
++ (void)load {
+    id cedarHooksProtocol = NSProtocolFromString(@"CDRHooks");
+    if (cedarHooksProtocol) {
+        class_addProtocol(self, cedarHooksProtocol);
+    }
+}
+
 + (void)beforeEach {
     [self resetAll];
 }

--- a/Foundation/SpecHelper/Extensions/NSUUID+Spec.h
+++ b/Foundation/SpecHelper/Extensions/NSUUID+Spec.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
 @interface NSUUID (Spec)
-+(NSArray *)generatedUUIDs;
-+(void)reset;
++ (NSArray *)generatedUUIDs;
++ (void)reset;
 @end

--- a/Foundation/SpecHelper/Extensions/NSUUID+Spec.m
+++ b/Foundation/SpecHelper/Extensions/NSUUID+Spec.m
@@ -1,22 +1,27 @@
 #import "NSUUID+Spec.h"
 #import "NSObject+MethodRedirection.h"
+#import <objc/runtime.h>
 
 @interface NSUUID (Spec_Private)
-+(NSUUID *)UUIDWithoutLogging;
-+(NSUUID *)UUIDWithLogging;
++ (NSUUID *)UUIDWithoutLogging;
++ (NSUUID *)UUIDWithLogging;
 @end
 
 static NSMutableArray *uuids;
 @implementation NSUUID (Spec)
-+(NSArray *)generatedUUIDs {
++ (NSArray *)generatedUUIDs {
     return uuids;
 }
 
-+(void)beforeEach {
++ (void)beforeEach {
     [self reset];
 }
 
-+(void)load {
++ (void)load {
+    id cedarHooksProtocol = NSProtocolFromString(@"CDRHooks");
+    if (cedarHooksProtocol) {
+        class_addProtocol(self, cedarHooksProtocol);
+    }
     [NSUUID redirectClassSelector:@selector(UUID)
                               to:@selector(UUIDWithLogging)
                     andRenameItTo:@selector(UUIDWithoutLogging)];
@@ -24,14 +29,14 @@ static NSMutableArray *uuids;
     uuids = [[NSMutableArray alloc] init];
 }
 
-+(NSUUID *)UUIDWithLogging {
++ (NSUUID *)UUIDWithLogging {
     NSUUID *uuid = [self UUIDWithoutLogging];
     [uuids addObject:uuid];
 
     return uuid;
 }
 
-+(void)reset {
++ (void)reset {
     uuids = [[NSMutableArray alloc] init];
 }
 

--- a/UIKit/SpecHelper/Stubs/UIApplication+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIApplication+Spec.m
@@ -1,4 +1,5 @@
 #import "UIApplication+Spec.h"
+#import <objc/runtime.h>
 
 @implementation UIApplication (Spec)
 
@@ -6,6 +7,10 @@ static NSMutableArray *URLs = nil;
 
 + (void)load {
     URLs = [NSMutableArray array];
+    id cedarHooksProtocol = NSProtocolFromString(@"CDRHooks");
+    if (cedarHooksProtocol) {
+        class_addProtocol(self, cedarHooksProtocol);
+    }
 }
 
 + (void)afterEach {

--- a/UIKit/SpecHelper/Stubs/UIPopoverController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIPopoverController+Spec.m
@@ -3,6 +3,7 @@
 #endif
 
 #import "UIPopoverController+Spec.h"
+#import <objc/runtime.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -12,6 +13,13 @@ static __weak UIPopoverController *currentPopoverController__;
 static UIPopoverArrowDirection arrowDirectionMask__;
 
 #pragma clang diagnostic pop
+
++ (void)load {
+    id cedarHooksProtocol = NSProtocolFromString(@"CDRHooks");
+    if (cedarHooksProtocol) {
+        class_addProtocol(self, cedarHooksProtocol);
+    }
+}
 
 + (instancetype)currentPopoverController {
     return currentPopoverController__;

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.m
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.m
@@ -1,9 +1,17 @@
 #import "UIView+StubbedAnimation.h"
+#import <objc/runtime.h>
 
 static BOOL shouldImmediatelyExecuteAnimationBlocks__ = YES;
 static NSMutableArray *animations__;
 
 @implementation UIView (StubbedAnimation)
+
++ (void)load {
+    id cedarHooksProtocol = NSProtocolFromString(@"CDRHooks");
+    if (cedarHooksProtocol) {
+        class_addProtocol(self, cedarHooksProtocol);
+    }
+}
 
 + (NSTimeInterval)lastAnimationDuration {
     return [(PCKViewAnimation*)[animations__ lastObject] duration];

--- a/UIKit/SpecHelper/Stubs/iOS/UIActionSheet+Spec.m
+++ b/UIKit/SpecHelper/Stubs/iOS/UIActionSheet+Spec.m
@@ -3,6 +3,7 @@
 #endif
 
 #import "UIActionSheet+Spec.h"
+#import <objc/runtime.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -11,6 +12,13 @@
 
 static UIActionSheet *currentActionSheet__;
 static UIView *currentActionSheetView__;
+
++ (void)load {
+    id cedarHooksProtocol = NSProtocolFromString(@"CDRHooks");
+    if (cedarHooksProtocol) {
+        class_addProtocol(self, cedarHooksProtocol);
+    }
+}
 
 + (void)afterEach {
     [self reset];

--- a/UIKit/SpecHelper/Stubs/iOS/UIAlertView+Spec.m
+++ b/UIKit/SpecHelper/Stubs/iOS/UIAlertView+Spec.m
@@ -3,6 +3,7 @@
 #endif
 
 #import "UIAlertView+Spec.h"
+#import <objc/runtime.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -10,6 +11,13 @@
 @implementation UIAlertView (Spec)
 
 static NSMutableArray *alertViewStack__ = nil;
+
++ (void)load {
+    id cedarHooksProtocol = NSProtocolFromString(@"CDRHooks");
+    if (cedarHooksProtocol) {
+        class_addProtocol(self, cedarHooksProtocol);
+    }
+}
 
 + (void)afterEach {
     [self reset];

--- a/UIKit/SpecHelper/Stubs/iOS/UIImagePickerController+Spec.m
+++ b/UIKit/SpecHelper/Stubs/iOS/UIImagePickerController+Spec.m
@@ -6,6 +6,13 @@ static const NSNumber *cameraDevice__;
 
 @implementation UIImagePickerController (Spec)
 
++ (void)load {
+    id cedarHooksProtocol = NSProtocolFromString(@"CDRHooks");
+    if (cedarHooksProtocol) {
+        class_addProtocol(self, cedarHooksProtocol);
+    }
+}
+
 + (void)afterEach {
     [self reset];
 }

--- a/WatchKit/WatchKit/PCKMessageCapturer.m
+++ b/WatchKit/WatchKit/PCKMessageCapturer.m
@@ -1,4 +1,5 @@
 #import "PCKMessageCapturer.h"
+#import <objc/runtime.h>
 
 @implementation PCKMessageCapturer {
     NSMutableArray *_sent_messages;
@@ -7,6 +8,13 @@
 static NSMutableArray *sent_class_messages_array;
 
 #pragma mark - NSObject
+
++ (void)load {
+    id cedarHooksProtocol = NSProtocolFromString(@"CDRHooks");
+    if (cedarHooksProtocol) {
+        class_addProtocol(self, cedarHooksProtocol);
+    }
+}
 
 - (instancetype)init
 {

--- a/WatchKit/WatchKit/WKExtension.m
+++ b/WatchKit/WatchKit/WKExtension.m
@@ -1,4 +1,5 @@
 #import "WKExtension.h"
+#import <objc/runtime.h>
 
 @interface PCKMessageCapturer ()
 - (void)openSystemURL:(NSURL *)URL NS_REQUIRES_SUPER;
@@ -11,6 +12,13 @@
 @implementation WKExtension
 
 static WKExtension *__sharedExtension;
+
++ (void)load {
+    id cedarHooksProtocol = NSProtocolFromString(@"CDRHooks");
+    if (cedarHooksProtocol) {
+        class_addProtocol(self, cedarHooksProtocol);
+    }
+}
 
 + (void)setSharedExtension:(WKExtension *)sharedExtension {
     __sharedExtension = sharedExtension;


### PR DESCRIPTION
SpecHelpers with global callbacks now weakly conform to CDRHooks

Cedar 1.0 now requires this for the callbacks to be triggered. The protocol is looked up and added in `+load` on these classes. This is admittedly a minimal attempt that gets things working for now.

We should probably discuss how we feel about a more flexible registration system that supports other tools for the spec helpers at some point. @akitchen @briancroom @tjarratt Thoughts?