### PR TITLE
Add animation stubs for transitions

### DIFF
--- a/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.h
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.h
@@ -4,6 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PCKViewAnimation : NSObject
 
+@property (strong, nonatomic) UIView *withView;
 @property (assign, nonatomic) NSTimeInterval duration;
 @property (assign, nonatomic) NSTimeInterval delay;
 @property (assign, nonatomic) CGFloat springWithDamping;
@@ -20,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UIView (StubbedAnimation)
 
++ (UIView*)lastWithView;
 + (NSTimeInterval)lastAnimationDuration;
 + (NSTimeInterval)lastAnimationDelay;
 + (UIViewAnimationOptions)lastAnimationOptions;

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.h
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.h
@@ -5,6 +5,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PCKViewAnimation : NSObject
 
 @property (strong, nonatomic) UIView *withView;
+@property (strong, nonatomic) UIView *fromView;
+@property (strong, nonatomic) UIView *toView;
 @property (assign, nonatomic) NSTimeInterval duration;
 @property (assign, nonatomic) NSTimeInterval delay;
 @property (assign, nonatomic) CGFloat springWithDamping;
@@ -22,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface UIView (StubbedAnimation)
 
 + (UIView*)lastWithView;
++ (UIView*)lastFromView;
++ (UIView*)lastToView;
 + (NSTimeInterval)lastAnimationDuration;
 + (NSTimeInterval)lastAnimationDelay;
 + (UIViewAnimationOptions)lastAnimationOptions;

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.m
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.m
@@ -17,6 +17,14 @@ static NSMutableArray *animations__;
    return [(PCKViewAnimation*)[animations__ lastObject] withView];
 }
 
++ (UIView*)lastFromView {
+    return [(PCKViewAnimation*)[animations__ lastObject] fromView];
+}
+
++ (UIView*)lastToView {
+    return [(PCKViewAnimation*)[animations__ lastObject] toView];
+}
+
 + (NSTimeInterval)lastAnimationDuration {
     return [(PCKViewAnimation*)[animations__ lastObject] duration];
 }
@@ -117,6 +125,25 @@ static NSMutableArray *animations__;
     }
 }
 
++ (void)transitionFromView:(UIView *)fromView
+                    toView:(UIView *)toView
+                  duration:(NSTimeInterval)duration
+                   options:(UIViewAnimationOptions)options
+                completion:(void (^)(BOOL finished))completion {
+
+    PCKViewAnimation *animation = [[PCKViewAnimation alloc] init];
+    animation.fromView = fromView;
+    animation.toView = toView;
+    animation.duration = duration;
+    animation.options = options;
+    animation.completionBlock = completion;
+    [animations__ addObject:animation];
+
+    if (shouldImmediatelyExecuteAnimationBlocks__) {
+        [animation complete];
+    }
+}
+
 #pragma mark - CedarHooks
 
 + (void)beforeEach {
@@ -128,7 +155,9 @@ static NSMutableArray *animations__;
 @implementation PCKViewAnimation
 
 - (void)animate {
-    self.animationBlock();
+    if (self.animationBlock) {
+        self.animationBlock();
+    }
 }
 
 - (void)complete {

--- a/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.m
+++ b/UIKit/SpecHelper/Stubs/UIView+StubbedAnimation.m
@@ -13,6 +13,10 @@ static NSMutableArray *animations__;
     }
 }
 
++ (UIView*)lastWithView {
+   return [(PCKViewAnimation*)[animations__ lastObject] withView];
+}
+
 + (NSTimeInterval)lastAnimationDuration {
     return [(PCKViewAnimation*)[animations__ lastObject] duration];
 }
@@ -82,6 +86,26 @@ static NSMutableArray *animations__;
     animation.delay = delay;
     animation.springWithDamping = dampingRatio;
     animation.initialSpringVelocity = velocity;
+    animation.options = options;
+    animation.animationBlock = animations;
+    animation.completionBlock = completion;
+    [animations__ addObject:animation];
+
+    if (shouldImmediatelyExecuteAnimationBlocks__) {
+        [animation animate];
+        [animation complete];
+    }
+}
+
++ (void)transitionWithView:(UIView *)view
+                  duration:(NSTimeInterval)duration
+                   options:(UIViewAnimationOptions)options
+                animations:(void (^)(void))animations
+                completion:(void (^)(BOOL finished))completion {
+
+    PCKViewAnimation *animation = [[PCKViewAnimation alloc] init];
+    animation.withView = view;
+    animation.duration = duration;
     animation.options = options;
     animation.animationBlock = animations;
     animation.completionBlock = completion;


### PR DESCRIPTION
Adding animation stubs for 

+transitionWithView:duration:options:animations:completion:
+transitionFromView:toView:duration:options:completion: