### PR TITLE
Adds support for better gesture recognizer mocking

### DIFF
--- a/UIKit/SpecHelper/Stubs/UIGestureRecognizer+Spec.h
+++ b/UIKit/SpecHelper/Stubs/UIGestureRecognizer+Spec.h
@@ -5,6 +5,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface UIGestureRecognizer (Spec)
 
 - (void)recognize;
+- (void)recognizeWithState:(UIGestureRecognizerState)state NS_SWIFT_NAME(recognize(with:));
+
+- (void)setLocationInView:(CGPoint)point;
+- (void)enableLocationInViewMocking;
+- (void)disableLocationInViewMocking;
 
 + (void)whitelistClassForGestureSnooping:(Class)klass __attribute__((deprecated("Calling this method is no longer required")));
 

--- a/UIKit/SpecHelper/Stubs/UIGestureRecognizer+Spec.m
+++ b/UIKit/SpecHelper/Stubs/UIGestureRecognizer+Spec.m
@@ -7,6 +7,7 @@
 #import "PCKMethodRedirector.h"
 
 static NSString * const kGestureStateKey = @"state";
+static NSString * const kLocationInViewKey = @"kLocationInView";
 
 @interface UIGestureRecognizerTarget : NSObject
 - (SEL)_action;
@@ -16,10 +17,87 @@ static NSString * const kGestureStateKey = @"state";
 - (void)_resetGestureRecognizer;
 @end
 
+@interface UIGestureRecognizer (SpecPrivate)
+- (CGPoint)_locationInView:(UIView *)view;
+@end
+
+UIView *oldestParentView(UIView *view);
+BOOL viewSharesHierarchy(UIView *view, UIView *otherView);
+
 @implementation UIGestureRecognizer (Spec)
 
 #pragma mark - Public interface
+
 - (void)recognize {
+    [self sharedRecognitionWithState:UIGestureRecognizerStateEnded];
+
+    [self _resetGestureRecognizer];
+    [self setValue:@(UIGestureRecognizerStatePossible) forKey:kGestureStateKey];
+}
+
+- (void)recognizeWithState:(UIGestureRecognizerState)state {
+    [self sharedRecognitionWithState:state];
+}
+
+- (void)setLocationInView:(CGPoint)point {
+    objc_setAssociatedObject(self, kLocationInViewKey, [NSValue valueWithCGPoint:point], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (void)enableLocationInViewMocking {
+    [self setLocationInViewMocking:YES];
+}
+
+- (void)disableLocationInViewMocking {
+    [self setLocationInViewMocking:NO];
+}
+
+- (void)setLocationInViewMocking:(BOOL)enable {
+    SEL preservedSelector = NSSelectorFromString(@"original_locationInView:");
+    Method originalMethod = class_getInstanceMethod([self class], @selector(locationInView:));
+    if (enable) {
+        class_addMethod(
+            [self class],
+            preservedSelector,
+            method_getImplementation(originalMethod),
+            method_getTypeEncoding(originalMethod)
+        );
+        method_setImplementation(
+            originalMethod,
+            method_getImplementation(class_getInstanceMethod([self class], @selector(pck_locationInView:)))
+        );
+    } else {
+        Method preservedMethod = class_getInstanceMethod([self class], preservedSelector);
+        if (preservedMethod == NULL) { return; }
+
+        IMP preservedImplementation = method_getImplementation(preservedMethod);
+        method_setImplementation(originalMethod, preservedImplementation);
+    }
+}
+
+- (CGPoint)pck_locationInView:(UIView *)view {
+    NSValue *pointValue = objc_getAssociatedObject(self, kLocationInViewKey);
+    CGPoint point = [pointValue CGPointValue];
+    if (view == self.view) {
+        return point;
+    } else if (view == nil) {
+        if (self.view.window == nil) {
+            [[NSException exceptionWithName:@"No valid location"
+                                     reason:@"Can't give location in view with no view and gesture recognizer not part of a window hierarchy"
+                                   userInfo:nil] raise];
+        } else {
+            view = self.view.window;
+        }
+    } else if (!viewSharesHierarchy(self.view, view)) {
+        [[NSException exceptionWithName:@"No valid location"
+                                 reason:@"Can't give location in view not related to gesture recognizer's view"
+                               userInfo:nil] raise];
+    }
+    return [self.view convertPoint:point toView:view];
+}
+
++ (void)whitelistClassForGestureSnooping:(Class)klass {}
+
+- (void)sharedRecognitionWithState:(UIGestureRecognizerState)state {
     if (self.view == nil) {
         [[NSException exceptionWithName:@"Unrecognizable" reason:@"Can't recognize when not in a view" userInfo:nil] raise];
     }
@@ -30,8 +108,7 @@ static NSString * const kGestureStateKey = @"state";
         [[NSException exceptionWithName:@"Unrecognizable" reason:@"Can't recognize when recognizer is disabled" userInfo:nil] raise];
     }
 
-    [self setValue:@(UIGestureRecognizerStateEnded) forKey:kGestureStateKey];
-
+    [self setValue:@(state) forKey:kGestureStateKey];
 
     Class targetActionPairClass = NSClassFromString(@"UIGestureRecognizerTarget");
     Ivar targetIvar = class_getInstanceVariable(targetActionPairClass, "_target");
@@ -43,11 +120,17 @@ static NSString * const kGestureStateKey = @"state";
         SEL action = (SEL)object_getIvar(pair, actionIvar);
         [target performSelector:action withObject:self];
     }];
-
-    [self _resetGestureRecognizer];
-    [self setValue:@(UIGestureRecognizerStatePossible) forKey:kGestureStateKey];
 }
 
-+ (void)whitelistClassForGestureSnooping:(Class)klass {}
-
 @end
+
+BOOL viewSharesHierarchy(UIView *view, UIView *otherView) {
+    return oldestParentView(view) == oldestParentView(otherView);
+}
+
+UIView *oldestParentView(UIView *view) {
+    if (view.superview) {
+        return oldestParentView(view.superview);
+    }
+    return view;
+}


### PR DESCRIPTION
- Can specify the state of the gesture recognizer when it's recognized
- Can specify what the location in the given view being recognized is
  This requires that the recognizer be enabled for view mocking, due to method swizzling on subclasses